### PR TITLE
Change back flatcar-cloudinit to coreos-cloudinit

### DIFF
--- a/kola/tests/coretest/cloudinit.go
+++ b/kola/tests/coretest/cloudinit.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 )
 
-const cloudinitBinPath = "/usr/bin/flatcar-cloudinit"
+const cloudinitBinPath = "/usr/bin/coreos-cloudinit"
 
 func read(filename string) (string, error) {
 	bytes, err := ioutil.ReadFile(filename)

--- a/platform/api/packet/api.go
+++ b/platform/api/packet/api.go
@@ -385,7 +385,7 @@ RequiredBy=multi-user.target
 				},
 				ignition.File{
 					Filesystem: "root",
-					Path:       "/root/bin/flatcar-cloudinit",
+					Path:       "/root/bin/coreos-cloudinit",
 					Contents: ignition.FileContents{
 						Source: ignition.Url{
 							Scheme: "data",


### PR DESCRIPTION
There's no need to rename this since coreos-cloudinit is just the name of
the project.