### PR TITLE
kola,ore: use the right project name

### DIFF
--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -85,7 +85,7 @@ func init() {
 
 	// gce-specific options
 	sv(&kola.GCEOptions.Image, "gce-image", "projects/coreos-cloud/global/images/family/coreos-alpha", "GCE image, full api endpoints names are accepted if resource is in a different project")
-	sv(&kola.GCEOptions.Project, "gce-project", "Flatcar", "GCE project name")
+	sv(&kola.GCEOptions.Project, "gce-project", "flatcar-212911", "GCE project name")
 	sv(&kola.GCEOptions.Zone, "gce-zone", "us-central1-a", "GCE zone name")
 	sv(&kola.GCEOptions.MachineType, "gce-machinetype", "n1-standard-1", "GCE machine type")
 	sv(&kola.GCEOptions.DiskType, "gce-disktype", "pd-ssd", "GCE disk type")

--- a/cmd/ore/gcloud/gcloud.go
+++ b/cmd/ore/gcloud/gcloud.go
@@ -40,7 +40,7 @@ func init() {
 	sv := GCloud.PersistentFlags().StringVar
 
 	sv(&opts.Image, "image", "", "image name")
-	sv(&opts.Project, "project", "Flatcar", "project")
+	sv(&opts.Project, "project", "flatcar-212911", "project")
 	sv(&opts.Zone, "zone", "us-central1-a", "zone")
 	sv(&opts.MachineType, "machinetype", "n1-standard-1", "machine type")
 	sv(&opts.DiskType, "disktype", "pd-ssd", "disk type")


### PR DESCRIPTION
It turns out we had to use the ID, not the Name as shown in the Google
Cloud Console.