### PR TITLE
kola: check also for the systemd cgroup driver

### DIFF
--- a/kola/tests/docker/docker.go
+++ b/kola/tests/docker/docker.go
@@ -571,7 +571,7 @@ func testDockerInfo(expectedFs string, c cluster.TestCluster) {
 		c.Errorf("unexpected security options: %+v", info.SecurityOptions)
 	}
 
-	if info.CgroupDriver != "cgroupfs" {
+	if info.CgroupDriver != "cgroupfs" && info.CgroupDriver != "systemd" {
 		c.Errorf("unexpected cgroup driver %v", info.CgroupDriver)
 	}
 


### PR DESCRIPTION
Flatcar edge 2051.99.1 or newer has the cgroup driver "systemd" instead of "cgroupfs". So we need to also update Kola tests to avoid test failures like:

```
--- FAIL: docker.base (541.40s)
    --- FAIL: docker.base/docker-info (12.17s)
            docker.go:575: unexpected cgroup driver systemd
```
