### PR TITLE
platform: fix qemu key name to org/flatcar-linux

### DIFF
--- a/platform/qemu.go
+++ b/platform/qemu.go
@@ -280,7 +280,7 @@ func CreateQEMUCommand(board, uuid, biosImage, consolePath, confPath, diskImageP
 
 	if isIgnition {
 		qmCmd = append(qmCmd,
-			"-fw_cfg", "name=opt/com.coreos/config,file="+confPath)
+			"-fw_cfg", "name=opt/org.flatcar-linux/config,file="+confPath)
 	} else {
 		qmCmd = append(qmCmd,
 			"-fsdev", "local,id=cfg,security_model=none,readonly,path="+confPath,


### PR DESCRIPTION
To fix a wrong key name when running a qemu VM with ignition, we need to replace `opt/com.coreos` with `opt/org.flatcar-linux`.

See also https://github.com/flatcar-linux/ignition/issues/2