### PR TITLE
plume/release: skip azure if no config passed (again)

### DIFF
--- a/cmd/plume/release.go
+++ b/cmd/plume/release.go
@@ -387,6 +387,10 @@ func doAzure(ctx context.Context, client *http.Client, src *storage.Bucket, spec
 		return
 	}
 
+	if azureProfile == "" {
+		return
+	}
+
 	// channel name should be caps for azure image
 	imageName := fmt.Sprintf("%s-%s-%s", spec.Azure.Offer, strings.Title(specChannel), specVersion)
 


### PR DESCRIPTION
In the past we [disabled azure](https://github.com/flatcar-linux/mantle/pull/6) in case of no config in plume.
That change was removed during the latest upstream merge.
Let's get it back to the flatcar-master branch.