### PR TITLE
 Support for ARM architecture

### DIFF
--- a/cmd/plume/README.md
+++ b/cmd/plume/README.md
@@ -7,21 +7,29 @@ CoreOS release utility
 ### Build a release image with the SDK
 
 ```sh
+# Use same build ID for all boards
 export COREOS_BUILD_ID=$(date +%Y-%m-%d-%H%M)
 KEYID="<keyid>"
 gpg2 --armor --export "$KEYID" > ~/keyfile
-./build_packages
-./build_image --upload --sign="$KEYID" prod
+for board in amd64-usr arm64-usr; do
+    ./build_packages --board=$board
+    ./build_image --board=$board --upload --sign="$KEYID" prod
+done
+# amd64-usr only
 for format in ami_vmdk azure gce; do
-    ./image_to_vm.sh --format=$format --upload --sign="$KEYID"
+    ./image_to_vm.sh --prod_image --board=amd64-usr --format=$format --upload --sign="$KEYID"
 done
 ```
 
 ### Perform the "release"
 
 ```sh
-bin/plume pre-release -C user --verify-key ~/keyfile -V $version-$COREOS_BUILD_ID
-bin/plume release -C user -V <version>-$COREOS_BUILD_ID
+for board in amd64-usr arm64-usr; do
+    bin/plume pre-release -C user --verify-key ~/keyfile -B $board -V $version-$COREOS_BUILD_ID
+done
+for board in amd64-usr arm64-usr; do
+    bin/plume release -C user -B $board -V <version>-$COREOS_BUILD_ID
+done
 ```
 
 ### Clean up

--- a/cmd/plume/containerlinux.go
+++ b/cmd/plume/containerlinux.go
@@ -29,7 +29,7 @@ var (
 	specBoard         string
 	specChannel       string
 	specVersion       string
-	gceBoards         = []string{"amd64-usr"}
+	gceBoards         = []string{"amd64-usr", "arm64-usr"}
 	azureBoards       = []string{"amd64-usr"}
 	awsBoards         = []string{"amd64-usr"}
 	azureEnvironments = []azureEnvironmentSpec{

--- a/kola/tests/docker/docker.go
+++ b/kola/tests/docker/docker.go
@@ -64,10 +64,11 @@ func init() {
 		ExcludePlatforms: []string{"qemu-unpriv"},
 	})
 	register.Register(&register.Test{
-		Run:         dockerOldClient,
-		ClusterSize: 0,
-		Name:        "docker.oldclient",
-		Distros:     []string{"cl"},
+		Run:           dockerOldClient,
+		ClusterSize:   0,
+		Name:          "docker.oldclient",
+		Architectures: []string{"amd64"},
+		Distros:       []string{"cl"},
 	})
 	register.Register(&register.Test{
 		Run:         dockerUserns,

--- a/kola/tests/misc/grub.go
+++ b/kola/tests/misc/grub.go
@@ -152,6 +152,7 @@ func init() {
 		Name:             "cl.update.grubnop",
 		UserData:         grubUpdaterConf,
 		MinVersion:       semver.Version{Major: 1745},
+		Architectures: []string{"amd64"},
 		Distros:          []string{"cl"},
 		ExcludePlatforms: []string{"qemu-unpriv"},
 	})

--- a/kola/tests/misc/update.go
+++ b/kola/tests/misc/update.go
@@ -58,7 +58,7 @@ func init() {
 	register.Register(&register.Test{
 		Run:         RecoverBadUsr,
 		ClusterSize: 1,
-		Name:        "cl.update.badusr",
+		Name:        "coreos.update.badusr",
 		Flags:       []register.Flag{register.NoEmergencyShellCheck},
 		UserData:    disableUpdateEngine,
 		Distros:     []string{"cl"},
@@ -103,7 +103,7 @@ func RecoverBadVerity(c cluster.TestCluster) {
 	c.MustSSH(m, "sudo cp /boot/flatcar/vmlinuz-a /boot/flatcar/vmlinuz-b")
 
 	// invalidate verity hash on B kernel
-	c.MustSSH(m, "sudo dd of=/boot/flatcar/vmlinuz-b bs=1 seek=64 count=64 conv=notrunc status=none <<<0000000000000000000000000000000000000000000000000000000000000000")
+	c.MustSSH(m, fmt.Sprintf("sudo dd of=/boot/flatcar/vmlinuz-b bs=1 seek=%d count=64 conv=notrunc status=none <<<0000000000000000000000000000000000000000000000000000000000000000", getKernelVerityHashOffset(c)))
 
 	prioritizeUsr(c, m, "USR-B")
 	rebootWithEmergencyShellTimeout(c, m)
@@ -136,7 +136,7 @@ func RecoverBadUsr(c cluster.TestCluster) {
 	c.MustSSH(m, "sudo cp /boot/flatcar/vmlinuz-a /boot/flatcar/vmlinuz-b")
 
 	// update verity hash on B kernel
-	c.MustSSH(m, fmt.Sprintf("sudo dd of=/boot/flatcar/vmlinuz-b bs=1 seek=64 count=64 conv=notrunc status=none <<<%s", verityHash))
+	c.MustSSH(m, fmt.Sprintf("sudo dd of=/boot/flatcar/vmlinuz-b bs=1 seek=%d count=64 conv=notrunc status=none <<<%s", getKernelVerityHashOffset(c), verityHash))
 
 	prioritizeUsr(c, m, "USR-B")
 	rebootWithEmergencyShellTimeout(c, m)

--- a/kola/tests/misc/verity.go
+++ b/kola/tests/misc/verity.go
@@ -19,10 +19,12 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/coreos/mantle/kola"
 	"github.com/coreos/mantle/kola/cluster"
 	"github.com/coreos/mantle/kola/register"
 	"github.com/coreos/mantle/kola/tests/util"
 	"github.com/coreos/mantle/platform"
+	"github.com/coreos/mantle/platform/machine/qemu"
 )
 
 func init() {
@@ -48,8 +50,12 @@ func Verity(c cluster.TestCluster) {
 func VerityVerify(c cluster.TestCluster) {
 	m := c.Machines()[0]
 
+	// get offset of verity hash within kernel
+	rootOffset := getKernelVerityHashOffset(c)
+
 	// extract verity hash from kernel
-	hash := c.MustSSH(m, "dd if=/boot/flatcar/vmlinuz-a skip=64 count=64 bs=1 status=none")
+	ddcmd := fmt.Sprintf("dd if=/boot/flatcar/vmlinuz-a skip=%d count=64 bs=1 status=none", rootOffset)
+	hash := c.MustSSH(m, ddcmd)
 
 	// find /usr dev
 	usrdev := util.GetUsrDeviceNode(c, m)
@@ -115,6 +121,15 @@ func VerityCorruption(c cluster.TestCluster) {
 	if fields[3] != "C" {
 		c.Fatalf("dmsetup status usr reports verity is valid after corruption!")
 	}
+}
+
+// get offset of verity hash within kernel
+func getKernelVerityHashOffset(c cluster.TestCluster) int {
+	// assume ARM64 is only on QEMU for now
+	if _, ok := c.Cluster.(*qemu.Cluster); ok && kola.QEMUOptions.Board == "arm64-usr" {
+		return 512
+	}
+	return 64
 }
 
 func skipUnlessVerity(c cluster.TestCluster, m platform.Machine) {

--- a/kola/tests/rkt/rkt.go
+++ b/kola/tests/rkt/rkt.go
@@ -20,10 +20,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/coreos/mantle/kola"
 	"github.com/coreos/mantle/kola/cluster"
 	"github.com/coreos/mantle/kola/register"
 	"github.com/coreos/mantle/platform"
 	"github.com/coreos/mantle/platform/conf"
+	"github.com/coreos/mantle/platform/machine/qemu"
 	"github.com/coreos/mantle/util"
 )
 
@@ -148,14 +150,19 @@ func createTestAci(c cluster.TestCluster, m platform.Machine, name string, bins 
 	"acKind": "ImageManifest",
 	"acVersion": "0.8.9",
 	"name": "%s",
-	"labels": [{"name": "os","value": "linux"},{"name": "arch","value": "amd64"},{"name": "version","value": "latest"}]
+	"labels": [{"name": "os","value": "linux"},{"name": "arch","value": "%s"},{"name": "version","value": "latest"}]
 }`
+
+	arch := "amd64"
+	if _, ok := c.Cluster.(*qemu.Cluster); ok && kola.QEMUOptions.Board == "arm64-usr" {
+		arch = "aarch64"
+	}
 
 	c.MustSSH(m, `set -e
 	tmpdir=$(mktemp -d)
 	cd $tmpdir
 	cat > manifest <<EOF
-`+fmt.Sprintf(testAciManifest, name)+`
+`+fmt.Sprintf(testAciManifest, name, arch)+`
 EOF
 
 	mkdir rootfs


### PR DESCRIPTION
This PR consists of most changes to support ARM architecture for Flatcar Linux.

A bunch of changes are about reverting old commits that dropped ARM architecture, back in mid 2018.

Should be merged together with https://github.com/flatcar-linux/bootengine/pull/4 https://github.com/flatcar-linux/coreos-overlay/pull/88 https://github.com/flatcar-linux/scripts/pull/23.