### PR TITLE
kola/tests/misc/grub.go: Fix formatting with gofmt

### DIFF
--- a/kola/tests/misc/grub.go
+++ b/kola/tests/misc/grub.go
@@ -152,7 +152,7 @@ func init() {
 		Name:             "cl.update.grubnop",
 		UserData:         grubUpdaterConf,
 		MinVersion:       semver.Version{Major: 1745},
-		Architectures: []string{"amd64"},
+		Architectures:    []string{"amd64"},
 		Distros:          []string{"cl"},
 		ExcludePlatforms: []string{"qemu-unpriv"},
 	})


### PR DESCRIPTION
Needed because Jenkins tests against gofmt.