### PR TITLE
sdk: make cork enter mount binfmt_misc

### DIFF
--- a/sdk/enter.go
+++ b/sdk/enter.go
@@ -102,6 +102,7 @@ func (e *enter) MountAPI() error {
 		Opts string
 	}{
 		{"/proc", "proc", "ro,nosuid,nodev,noexec"},
+		{"/proc/sys/fs/binfmt_misc", "binfmt_misc", "rw,nosuid,nodev,noexec,relatime"},
 		{"/sys", "sysfs", "ro,nosuid,nodev,noexec"},
 		{"/run", "tmpfs", "nosuid,nodev,mode=755"},
 	}


### PR DESCRIPTION
So far `cork enter` has mounted only `/proc` inside the container, not `/proc/sys/fs/binfmt_misc`.
It caused the cross-build environment not to detect binfmt config changes.

Mount `binfmt_misc` into chroot to fix it.