### PR TITLE
kola: add raid0 tests for root and data devices

### DIFF
--- a/kola/tests/misc/raid.go
+++ b/kola/tests/misc/raid.go
@@ -136,6 +136,19 @@ func init() {
 		Distros:     []string{"cl"},
 	})
 
+	// data with raid0
+	tmplDataRaid0, _ := util.ExecTemplate(CLConfigDataRaid, raidConfig{
+		RaidLevel: "raid0",
+	})
+
+	register.Register(&register.Test{
+		Run:         DataOnRaid,
+		ClusterSize: 1,
+		Name:        "cl.disk.raid0.data",
+		UserData:    conf.ContainerLinuxConfig(tmplDataRaid0),
+		Distros:     []string{"cl"},
+	})
+
 	// data with raid1
 	tmplDataRaid1, _ := util.ExecTemplate(CLConfigDataRaid, raidConfig{
 		RaidLevel: "raid1",

--- a/kola/tests/util/template.go
+++ b/kola/tests/util/template.go
@@ -1,0 +1,34 @@
+// Copyright 2019 Kinvolk GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"bytes"
+	"text/template"
+)
+
+func ExecTemplate(tmplStr string, tmplData interface{}) (string, error) {
+	var out bytes.Buffer
+
+	tmpl, err := template.New("").Parse(tmplStr)
+	if err != nil {
+		return out.String(), err
+	}
+
+	if err := tmpl.Execute(&out, tmplData); err != nil {
+		return out.String(), err
+	}
+	return out.String(), nil
+}


### PR DESCRIPTION
We should test root and data devices not only with raid1 but also with raid0, to catch issues with raid0 devices.

To be able to parametrize raid levels for RAID tests, we should create a helper function `ExecTemplate()` that reads template and parses it into an actual output string. Also make the existing raid tests use `ExecTemplate()`.