### PR TITLE
sdk: reuse an existing GID upon cork create in a limited environment

### DIFF
--- a/sdk/create.go
+++ b/sdk/create.go
@@ -41,15 +41,21 @@ touch /etc/{group,gshadow,passwd,shadow}
 chmod 0640 /etc/{gshadow,shadow}
 
 # add group if it doesn't exist already
-if ! getent group {{printf "%q" .Groupname}} >/dev/null; then
+gid_new={{.Gid}}
+gid_prev=$(getent group {{printf "%q" .Groupname}} | cut -d: -f3)
+
+if [[ -z "$gid_prev" ]]; then
 	echo Adding group {{printf "%q" .Groupname}}
-	groupadd -o -g {{.Gid}} {{printf "%q" .Groupname}}
+	groupadd -o -g $gid_new {{printf "%q" .Groupname}}
+else
+	echo Using existing GID $gid_prev {{printf "%q" .Groupname}}
+	gid_new=$gid_prev
 fi
 
 # add user if it doesn't exist already
 if ! getent passwd {{printf "%q" .Username}} >/dev/null; then
 	echo Adding user {{printf "%q" .Username}}
-	useradd -o -g {{.Gid}} -u {{.Uid}} -s /bin/bash -m \
+	useradd -o -g $gid_new -u {{.Uid}} -s /bin/bash -m \
 		-c {{printf "%q" .Name}} {{printf "%q" .Username}}
 fi
 
@@ -129,7 +135,7 @@ source ~/trunk/src/scripts/bash_completion
 # Put your fun stuff here.
 EOF
 
-chown -R {{.Uid}}:{{.Gid}} "$HOME"
+chown -R {{.Uid}}:$gid_new "$HOME"
 
 # Checked in src/scripts/common.sh
 touch /etc/debian_chroot


### PR DESCRIPTION
In some cases, users might want to run `cork create` under a limited environment, where only limited GIDs are available. Github workflows CI is one of the examples, since each CI instance is a Docker container with the latest Ubuntu. In that case, outside of the cork chroot, GID for group `docker` is `115`, while inside of the chroot, GID for group
`docker` is `233`.

So when `cork create` tries to run a script which tries to run `useradd -u UID -g 115` inside the chroot, it fails because of the missing GID 115.

So we should actually make the internal script detect the existing GID 233 to be used for GID of `useradd` command.