### PR TITLE
Increase RAM for QEMU machines

### DIFF
--- a/platform/qemu.go
+++ b/platform/qemu.go
@@ -239,7 +239,7 @@ func CreateQEMUCommand(board, uuid, biosImage, consolePath, confPath, diskImageP
 			"qemu-system-x86_64",
 			"-machine", "accel=kvm",
 			"-cpu", "host",
-			"-m", "1024",
+			"-m", "1280",
 		}
 	case "amd64--arm64-usr":
 		qmBinary = "qemu-system-aarch64"
@@ -255,7 +255,7 @@ func CreateQEMUCommand(board, uuid, biosImage, consolePath, confPath, diskImageP
 			"qemu-system-x86_64",
 			"-machine", "pc-q35-2.8",
 			"-cpu", "kvm64",
-			"-m", "1024",
+			"-m", "1280",
 		}
 	case "arm64--arm64-usr":
 		qmBinary = "qemu-system-aarch64"


### PR DESCRIPTION
Some tests where multiple containers are
spawned in parallel were failing because
of out-out-memory errors.
Slightly increase the memory to allow for
the failing containers to be spawned.

**Note:** Should be cherry-picked for -edge and alpha.