### PR TITLE
packet: Increase provisioning timeout because of iPXE boot

### DIFF
--- a/platform/api/packet/api.go
+++ b/platform/api/packet/api.go
@@ -44,7 +44,7 @@ const (
 	// Provisioning a VM is supposed to take < 8 minutes, but in practice can take longer.
 	launchTimeout       = 10 * time.Minute
 	launchPollInterval  = 30 * time.Second
-	installTimeout      = 15 * time.Minute
+	installTimeout      = 30 * time.Minute
 	installPollInterval = 5 * time.Second
 	apiRetries          = 3
 	apiRetryInterval    = 5 * time.Second


### PR DESCRIPTION
The kola test times out because the iPXE boot takes too long to get the full installation done in time.

**Note:** Pick for alpha and edge.