### PR TITLE
platform: Increase SSH retries to wait up to 10 min

### DIFF
--- a/platform/platform.go
+++ b/platform/platform.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	sshRetries = 30
+	sshRetries = 60
 	sshTimeout = 10 * time.Second
 )
 


### PR DESCRIPTION
Sometimes it may take longer, so tolerate these cases.
Also, give more time to check the instance manually
before it is deleted due to a timeout.