### PR TITLE
kola/tests/etcd: Double timeout duration from 2.5 to 5 min

### DIFF
--- a/kola/tests/etcd/util.go
+++ b/kola/tests/etcd/util.go
@@ -50,7 +50,7 @@ func GetClusterHealth(c cluster.TestCluster, m platform.Machine, csize int) erro
 		return nil
 	}
 
-	err = util.Retry(15, 10*time.Second, checker)
+	err = util.Retry(30, 10*time.Second, checker)
 	if err != nil {
 		return fmt.Errorf("health polling failed: %v: %s", err, b)
 	}


### PR DESCRIPTION
Increase timeout for etcd cluster to come up. This also
gives more time to check the server manually before it
is deleted due to the timeout.