### PR TITLE
plume: Include -arm64 in AMI name for arm64 images

### DIFF
--- a/cmd/ore/aws/upload.go
+++ b/cmd/ore/aws/upload.go
@@ -178,6 +178,17 @@ func runUpload(cmd *cobra.Command, args []string) error {
 		amiName = fmt.Sprintf("Container-Linux-dev-%s-%s", os.Getenv("USER"), awsVersion)
 	}
 
+	switch uploadBoard {
+	case "amd64-usr":
+	case "arm64-usr":
+		if !strings.HasSuffix(amiName, "-arm64") {
+			amiName = amiName + "-arm64"
+		}
+	default:
+		fmt.Fprintf(os.Stderr, "No AMI name suffix known for board %q\n", uploadBoard)
+		os.Exit(1)
+	}
+
 	var s3URL *url.URL
 	var err error
 	if uploadSourceObject != "" {

--- a/cmd/plume/containerlinux.go
+++ b/cmd/plume/containerlinux.go
@@ -180,6 +180,18 @@ func AddSpecFlags(flags *pflag.FlagSet) {
 		versions.VersionID, "release version")
 }
 
+func AmiNameArchTag() string {
+	switch specBoard {
+	case "amd64-usr":
+		return ""
+	case "arm64-usr":
+		return "-arm64"
+	default:
+		plog.Fatalf("No AMI name architecture tag defined for board %q", specBoard)
+		return "" // dummy
+	}
+}
+
 func ChannelSpec() channelSpec {
 	if specBoard == "" {
 		plog.Fatal("--board is required")

--- a/cmd/plume/prerelease.go
+++ b/cmd/plume/prerelease.go
@@ -546,7 +546,7 @@ func awsUploadToPartition(spec *channelSpec, part *awsPartitionSpec, imageName, 
 
 	plog.Printf("Creating AMIs from %v...", snapshot.SnapshotID)
 
-	hvmImageID, err := api.CreateHVMImage(snapshot.SnapshotID, aws.ContainerLinuxDiskSizeGiB, imageName+"-hvm", imageDescription+" (HVM)")
+	hvmImageID, err := api.CreateHVMImage(snapshot.SnapshotID, aws.ContainerLinuxDiskSizeGiB, imageName+AmiNameArchTag()+"-hvm", imageDescription+" (HVM)")
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to create HVM image: %v", err)
 	}
@@ -554,7 +554,7 @@ func awsUploadToPartition(spec *channelSpec, part *awsPartitionSpec, imageName, 
 
 	var pvImageID string
 	if selectedDistro == "cl" {
-		pvImageID, err = api.CreatePVImage(snapshot.SnapshotID, aws.ContainerLinuxDiskSizeGiB, imageName, imageDescription+" (PV)")
+		pvImageID, err = api.CreatePVImage(snapshot.SnapshotID, aws.ContainerLinuxDiskSizeGiB, imageName+AmiNameArchTag(), imageDescription+" (PV)")
 		if err != nil {
 			return nil, nil, fmt.Errorf("unable to create PV image: %v", err)
 		}

--- a/cmd/plume/release.go
+++ b/cmd/plume/release.go
@@ -461,9 +461,9 @@ func doAWS(ctx context.Context, client *http.Client, src *storage.Bucket, spec *
 				}
 			}
 			if aws.RegionSupportsPV(region) {
-				publish(imageName)
+				publish(imageName + AmiNameArchTag())
 			}
-			publish(imageName + "-hvm")
+			publish(imageName + AmiNameArchTag() + "-hvm")
 		}
 	}
 }


### PR DESCRIPTION
Currently the AMI names clash for amd64 and arm64 releases.
Therefore, no AMIs for arm64 were created.
Add a "-arm64" tag to the AMI name to distinguish the
arm64 AMI names. This introduces no change to the AMI name
for the existing amd64 AMIs.