### PR TITLE
ore|plume: Remove PV support

### DIFF
--- a/cmd/ore/aws/upload.go
+++ b/cmd/ore/aws/upload.go
@@ -32,7 +32,7 @@ var (
 	cmdUpload = &cobra.Command{
 		Use:   "upload",
 		Short: "Create AWS images",
-		Long: `Upload CoreOS image to S3 and create relevant AMIs (hvm and pv).
+		Long: `Upload CoreOS image to S3 and create relevant AMIs (hvm).
 
 Supported source formats are VMDK (as created with ./image_to_vm --format=ami_vmdk) and RAW.
 
@@ -60,7 +60,6 @@ After a successful run, the final line of output will be a line of JSON describi
 	uploadAMIName         string
 	uploadAMIDescription  string
 	uploadGrantUsers      []string
-	uploadCreatePV        bool
 	uploadTags            []string
 )
 
@@ -82,7 +81,6 @@ func init() {
 	cmdUpload.Flags().StringVar(&uploadAMIName, "ami-name", "", "name of the AMI to create (default: Container-Linux-$USER-$VERSION)")
 	cmdUpload.Flags().StringVar(&uploadAMIDescription, "ami-description", "", "description of the AMI to create (default: empty)")
 	cmdUpload.Flags().StringSliceVar(&uploadGrantUsers, "grant-user", []string{}, "grant launch permission to this AWS user ID")
-	cmdUpload.Flags().BoolVar(&uploadCreatePV, "create-pv", false, "create a PV AMI in addition to the HVM AMI")
 	cmdUpload.Flags().StringSliceVar(&uploadTags, "tags", []string{}, "list of key=value tags to attach to the AMI")
 }
 
@@ -294,37 +292,12 @@ func runUpload(cmd *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 
-	var pvID string
-	if uploadCreatePV {
-		pvImageID, err := API.CreatePVImage(sourceSnapshot, uploadDiskSizeGiB, amiName, uploadAMIDescription)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "unable to create PV image: %v\n", err)
-			os.Exit(1)
-		}
-		pvID = pvImageID
-
-		if len(uploadGrantUsers) > 0 {
-			err = API.GrantLaunchPermission(pvID, uploadGrantUsers)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "unable to grant launch permission: %v\n", err)
-				os.Exit(1)
-			}
-		}
-
-		if err := API.CreateTags([]string{pvID}, tagMap); err != nil {
-			fmt.Fprintf(os.Stderr, "unable to add tags: %v\n", err)
-			os.Exit(1)
-		}
-	}
-
 	err = json.NewEncoder(os.Stdout).Encode(&struct {
 		HVM        string
-		PV         string `json:",omitempty"`
 		SnapshotID string
 		S3Object   string
 	}{
 		HVM:        hvmID,
-		PV:         pvID,
 		SnapshotID: sourceSnapshot,
 		S3Object:   s3URL.String(),
 	})

--- a/cmd/plume/prerelease.go
+++ b/cmd/plume/prerelease.go
@@ -474,7 +474,7 @@ func getSpecAWSImageMetadata(spec *channelSpec) (map[string]string, error) {
 	return awsImageMetaData, nil
 }
 
-func awsUploadToPartition(spec *channelSpec, part *awsPartitionSpec, imageName, imageDescription, imagePath string) (map[string]string, map[string]string, error) {
+func awsUploadToPartition(spec *channelSpec, part *awsPartitionSpec, imageName, imageDescription, imagePath string) (map[string]string, error) {
 	plog.Printf("Connecting to %v...", part.Name)
 	api, err := aws.New(&aws.Options{
 		CredentialsFile: awsCredentialsFile,
@@ -482,18 +482,18 @@ func awsUploadToPartition(spec *channelSpec, part *awsPartitionSpec, imageName, 
 		Region:          part.BucketRegion,
 	})
 	if err != nil {
-		return nil, nil, fmt.Errorf("creating client for %v: %v", part.Name, err)
+		return nil, fmt.Errorf("creating client for %v: %v", part.Name, err)
 	}
 
 	f, err := os.Open(imagePath)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Could not open image file %v: %v", imagePath, err)
+		return nil, fmt.Errorf("Could not open image file %v: %v", imagePath, err)
 	}
 	defer f.Close()
 
 	awsImageMetadata, err := getSpecAWSImageMetadata(spec)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Could not generate the image metadata: %v", err)
+		return nil, fmt.Errorf("Could not generate the image metadata: %v", err)
 	}
 
 	imageFileName := awsImageMetadata["imageFileName"]
@@ -511,14 +511,14 @@ func awsUploadToPartition(spec *channelSpec, part *awsPartitionSpec, imageName, 
 
 	snapshot, err := api.FindSnapshot(imageName)
 	if err != nil {
-		return nil, nil, fmt.Errorf("unable to check for snapshot: %v", err)
+		return nil, fmt.Errorf("unable to check for snapshot: %v", err)
 	}
 
 	if snapshot == nil {
 		plog.Printf("Creating S3 object %v...", s3ObjectURL)
 		err = api.UploadObject(f, part.Bucket, s3ObjectPath, false)
 		if err != nil {
-			return nil, nil, fmt.Errorf("Error uploading: %v", err)
+			return nil, fmt.Errorf("Error uploading: %v", err)
 		}
 
 		plog.Printf("Creating EBS snapshot...")
@@ -533,7 +533,7 @@ func awsUploadToPartition(spec *channelSpec, part *awsPartitionSpec, imageName, 
 
 		snapshot, err = api.CreateSnapshot(imageName, s3ObjectURL, format)
 		if err != nil {
-			return nil, nil, fmt.Errorf("unable to create snapshot: %v", err)
+			return nil, fmt.Errorf("unable to create snapshot: %v", err)
 		}
 	}
 
@@ -541,25 +541,16 @@ func awsUploadToPartition(spec *channelSpec, part *awsPartitionSpec, imageName, 
 	plog.Printf("Deleting S3 object %v...", s3ObjectURL)
 	err = api.DeleteObject(part.Bucket, s3ObjectPath)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Error deleting S3 object: %v", err)
+		return nil, fmt.Errorf("Error deleting S3 object: %v", err)
 	}
 
 	plog.Printf("Creating AMIs from %v...", snapshot.SnapshotID)
 
 	hvmImageID, err := api.CreateHVMImage(snapshot.SnapshotID, aws.ContainerLinuxDiskSizeGiB, imageName+AmiNameArchTag()+"-hvm", imageDescription+" (HVM)")
 	if err != nil {
-		return nil, nil, fmt.Errorf("unable to create HVM image: %v", err)
+		return nil, fmt.Errorf("unable to create HVM image: %v", err)
 	}
 	resources := []string{snapshot.SnapshotID, hvmImageID}
-
-	var pvImageID string
-	if selectedDistro == "cl" {
-		pvImageID, err = api.CreatePVImage(snapshot.SnapshotID, aws.ContainerLinuxDiskSizeGiB, imageName+AmiNameArchTag(), imageDescription+" (PV)")
-		if err != nil {
-			return nil, nil, fmt.Errorf("unable to create PV image: %v", err)
-		}
-		resources = append(resources, pvImageID)
-	}
 
 	switch selectedDistro {
 	case "cl":
@@ -568,7 +559,7 @@ func awsUploadToPartition(spec *channelSpec, part *awsPartitionSpec, imageName, 
 			"Version": specVersion,
 		})
 		if err != nil {
-			return nil, nil, fmt.Errorf("couldn't tag images: %v", err)
+			return nil, fmt.Errorf("couldn't tag images: %v", err)
 		}
 	case "fedora":
 		err = api.CreateTags(resources, map[string]string{
@@ -577,11 +568,11 @@ func awsUploadToPartition(spec *channelSpec, part *awsPartitionSpec, imageName, 
 			"ComposeID": specComposeID,
 		})
 		if err != nil {
-			return nil, nil, fmt.Errorf("couldn't tag images: %v", err)
+			return nil, fmt.Errorf("couldn't tag images: %v", err)
 		}
 	}
 
-	postprocess := func(imageID string, pv bool) (map[string]string, error) {
+	postprocess := func(imageID string) (map[string]string, error) {
 		if len(part.LaunchPermissions) > 0 {
 			if err := api.GrantLaunchPermission(imageID, part.LaunchPermissions); err != nil {
 				return nil, err
@@ -592,11 +583,7 @@ func awsUploadToPartition(spec *channelSpec, part *awsPartitionSpec, imageName, 
 		foundBucketRegion := false
 		for _, region := range part.Regions {
 			if region != part.BucketRegion {
-				if pv && !aws.RegionSupportsPV(region) {
-					plog.Debugf("%v doesn't support PV AMIs; skipping", region)
-				} else {
-					destRegions = append(destRegions, region)
-				}
+				destRegions = append(destRegions, region)
 			} else {
 				foundBucketRegion = true
 			}
@@ -620,25 +607,16 @@ func awsUploadToPartition(spec *channelSpec, part *awsPartitionSpec, imageName, 
 		return amis, nil
 	}
 
-	hvmAmis, err := postprocess(hvmImageID, false)
+	hvmAmis, err := postprocess(hvmImageID)
 	if err != nil {
-		return nil, nil, fmt.Errorf("processing HVM images: %v", err)
+		return nil, fmt.Errorf("processing HVM images: %v", err)
 	}
 
-	var pvAmis map[string]string
-	if selectedDistro == "cl" {
-		pvAmis, err = postprocess(pvImageID, true)
-		if err != nil {
-			return nil, nil, fmt.Errorf("processing PV images: %v", err)
-		}
-	}
-
-	return hvmAmis, pvAmis, nil
+	return hvmAmis, nil
 }
 
 type amiListEntry struct {
 	Region string `json:"name"`
-	PvAmi  string `json:"pv,omitempty"`
 	HvmAmi string `json:"hvm"`
 }
 
@@ -683,33 +661,21 @@ func awsUploadAmiLists(ctx context.Context, bucket *storage.Bucket, spec *channe
 	jsonAll := jsonBuf.String()
 
 	// format text AMI lists and upload AMI IDs for individual regions
-	var hvmRecords, pvRecords []string
+	var hvmRecords []string
 	for _, entry := range amis.Entries {
 		hvmRecords = append(hvmRecords,
 			fmt.Sprintf("%v=%v", entry.Region, entry.HvmAmi))
-		if entry.PvAmi != "" {
-			pvRecords = append(pvRecords,
-				fmt.Sprintf("%v=%v", entry.Region, entry.PvAmi))
-		}
 
 		if err := upload(fmt.Sprintf("hvm_%v.txt", entry.Region),
 			entry.HvmAmi+"\n"); err != nil {
 			return err
 		}
-		if entry.PvAmi != "" {
-			if err := upload(fmt.Sprintf("pv_%v.txt", entry.Region),
-				entry.PvAmi+"\n"); err != nil {
-				return err
-			}
-			// compatibility
-			if err := upload(fmt.Sprintf("%v.txt", entry.Region),
-				entry.PvAmi+"\n"); err != nil {
-				return err
-			}
+		if err := upload(fmt.Sprintf("%v.txt", entry.Region),
+			entry.HvmAmi+"\n"); err != nil {
+			return err
 		}
 	}
 	hvmAll := strings.Join(hvmRecords, "|") + "\n"
-	pvAll := strings.Join(pvRecords, "|") + "\n"
 
 	// upload AMI lists
 	if err := upload("all.json", jsonAll); err != nil {
@@ -718,11 +684,8 @@ func awsUploadAmiLists(ctx context.Context, bucket *storage.Bucket, spec *channe
 	if err := upload("hvm.txt", hvmAll); err != nil {
 		return err
 	}
-	if err := upload("pv.txt", pvAll); err != nil {
-		return err
-	}
 	// compatibility
-	if err := upload("all.txt", pvAll); err != nil {
+	if err := upload("all.txt", hvmAll); err != nil {
 		return err
 	}
 
@@ -732,7 +695,7 @@ func awsUploadAmiLists(ctx context.Context, bucket *storage.Bucket, spec *channe
 // awsPreRelease runs everything necessary to prepare a CoreOS release for AWS.
 //
 // This includes uploading the ami_vmdk image to an S3 bucket in each EC2
-// partition, creating HVM and PV AMIs, and replicating the AMIs to each
+// partition, creating HVM AMIs, and replicating the AMIs to each
 // region.
 func awsPreRelease(ctx context.Context, client *http.Client, src *storage.Bucket, spec *channelSpec, imageInfo *imageInfo) error {
 	if spec.AWS.Image == "" {
@@ -756,7 +719,7 @@ func awsPreRelease(ctx context.Context, client *http.Client, src *storage.Bucket
 
 	var amis amiList
 	for i := range spec.AWS.Partitions {
-		hvmAmis, pvAmis, err := awsUploadToPartition(spec, &spec.AWS.Partitions[i], imageName, imageDescription, imagePath)
+		hvmAmis, err := awsUploadToPartition(spec, &spec.AWS.Partitions[i], imageName, imageDescription, imagePath)
 		if err != nil {
 			return err
 		}
@@ -764,7 +727,6 @@ func awsPreRelease(ctx context.Context, client *http.Client, src *storage.Bucket
 		for region := range hvmAmis {
 			amis.Entries = append(amis.Entries, amiListEntry{
 				Region: region,
-				PvAmi:  pvAmis[region],
 				HvmAmi: hvmAmis[region],
 			})
 		}

--- a/cmd/plume/release.go
+++ b/cmd/plume/release.go
@@ -460,9 +460,6 @@ func doAWS(ctx context.Context, client *http.Client, src *storage.Bucket, spec *
 					}
 				}
 			}
-			if aws.RegionSupportsPV(region) {
-				publish(imageName + AmiNameArchTag())
-			}
 			publish(imageName + AmiNameArchTag() + "-hvm")
 		}
 	}

--- a/platform/api/aws/ami.go
+++ b/platform/api/aws/ami.go
@@ -26,7 +26,6 @@ import (
 type releaseAMIs struct {
 	AMIS []struct {
 		Name string `json:"name"`
-		PV   string `json:"pv"`
 		HVM  string `json:"hvm"`
 	} `json:"amis"`
 }


### PR DESCRIPTION
Removes uploading of the deprecated AWS PV AMIs in `ore` and `plume`.