### PR TITLE
cmd/plume/containerlinux: Disable ap-northeast-3

### DIFF
--- a/cmd/plume/containerlinux.go
+++ b/cmd/plume/containerlinux.go
@@ -60,7 +60,7 @@ var (
 				"ap-southeast-2",
 				"ap-northeast-1",
 				"ap-northeast-2",
-				"ap-northeast-3",
+				// "ap-northeast-3", // Disabled for now because we do not have access
 				"sa-east-1",
 				"ca-central-1",
 				"ap-east-1",


### PR DESCRIPTION
Even though ap-northeast-3 is specified as default
region, it is not available by default at the moment.