### PR TITLE
platform: increase RAM to 2G for amd64 as well

### DIFF
--- a/platform/qemu.go
+++ b/platform/qemu.go
@@ -239,7 +239,7 @@ func CreateQEMUCommand(board, uuid, biosImage, consolePath, confPath, diskImageP
 			"qemu-system-x86_64",
 			"-machine", "accel=kvm",
 			"-cpu", "host",
-			"-m", "1280",
+			"-m", "2048",
 		}
 	case "amd64--arm64-usr":
 		qmBinary = "qemu-system-aarch64"
@@ -255,7 +255,7 @@ func CreateQEMUCommand(board, uuid, biosImage, consolePath, confPath, diskImageP
 			"qemu-system-x86_64",
 			"-machine", "pc-q35-2.8",
 			"-cpu", "kvm64",
-			"-m", "1280",
+			"-m", "2048",
 		}
 	case "arm64--arm64-usr":
 		qmBinary = "qemu-system-aarch64"


### PR DESCRIPTION
Since systemd v243, systemd-journald start crashing with OOM when the test VM runs with RAM of 1280M.

So we need to increase RAM to 2G for amd64 as well, to make it run without OOM.