### PR TITLE
kola: remove tests for docker 1.12 torcx profile

### DIFF
--- a/kola/tests/docker/docker.go
+++ b/kola/tests/docker/docker.go
@@ -564,9 +564,6 @@ func testDockerInfo(expectedFs string, c cluster.TestCluster) {
 	// Because we prefer overlay2/overlay for different docker versions, figure
 	// out the correct driver to be testing for based on our docker version.
 	expectedOverlayDriver := "overlay2"
-	if strings.HasPrefix(info.ServerVersion, "1.12.") || strings.HasPrefix(info.ServerVersion, "17.04.") {
-		expectedOverlayDriver = "overlay"
-	}
 
 	expectedFsDriverMap := map[string]string{
 		"overlay":      expectedOverlayDriver,

--- a/kola/tests/docker/torcx_docker_flag.go
+++ b/kola/tests/docker/torcx_docker_flag.go
@@ -34,7 +34,7 @@ storage:
     - filesystem: root
       path: /etc/flatcar/docker-1.12
       contents:
-        inline: yes
+        inline: no
       mode: 0644
 `),
 		Distros: []string{"cl"},
@@ -47,7 +47,7 @@ storage:
 #cloud-config
 write_files:
   - path: "/etc/flatcar/docker-1.12"
-    content: yes
+    content: no
 `),
 		Distros:          []string{"cl"},
 		ExcludePlatforms: []string{"qemu-unpriv"},
@@ -57,15 +57,7 @@ write_files:
 func dockerTorcxFlagFile(c cluster.TestCluster) {
 	m := c.Machines()[0]
 
-	// flag=yes
-	checkTorcxDockerVersions(c, m, `^1\.12$`, `^1\.12\.`)
-
 	// flag=no
-	c.MustSSH(m, "echo no | sudo tee /etc/flatcar/docker-1.12")
-	if err := m.Reboot(); err != nil {
-		c.Fatalf("could not reboot: %v", err)
-	}
-	c.MustSSH(m, `sudo rm -rf /var/lib/docker`)
 	checkTorcxDockerVersions(c, m, `^1[7-9]\.`, `^1[7-9]\.`)
 }
 
@@ -77,8 +69,8 @@ func dockerTorcxFlagFileCloudConfig(c cluster.TestCluster) {
 		c.Fatalf("couldn't reboot: %v", err)
 	}
 
-	// flag=yes
-	checkTorcxDockerVersions(c, m, `^1\.12$`, `^1\.12\.`)
+	// flag=no
+	checkTorcxDockerVersions(c, m, `^1[7-9]\.`, `^1[7-9]\.`)
 }
 
 func checkTorcxDockerVersions(c cluster.TestCluster, m platform.Machine, expectedRefRE, expectedVerRE string) {


### PR DESCRIPTION
Since the docker 1.12 profile was removed in Edge, many kola tests started to fail to run, because of the missing docker 1.12 profile. Ideally we should be able to make a different set of profiles for each channel.
Unfortunately the current Jenkins pipeline is not able to do that. It takes into account only flatcar-master branch.

Let's remove tests for the docker 1.12 profile. It will not be so big deal, because anyway Stable and Beta have been using docker 18 since a long time.