### PR TITLE
kola: Improve debugging abilities through SSH login

### DIFF
--- a/kola/tests/kubernetes/controllerInstall.go
+++ b/kola/tests/kubernetes/controllerInstall.go
@@ -2,7 +2,7 @@ package kubernetes
 
 // https://github.com/coreos/coreos-kubernetes/tree/master/multi-node/generic.
 // The only change besides paramaterizing the env vars was:
-// s/FLATCAR_PUBLIC_IP/FLATCAR_PRIVATE so this works on GCE.
+// s/COREOS_PUBLIC_IP/COREOS_PRIVATE_IPV4 so this works on GCE.
 const controllerInstallScript = `#!/bin/bash
 set -e
 
@@ -54,7 +54,7 @@ function init_config {
     fi
 
     if [ -z $ADVERTISE_IP ]; then
-        export ADVERTISE_IP=$(awk -F= '/FLATCAR_PRIVATE_IPV4/ {print $2}' /etc/environment)
+        export ADVERTISE_IP=$(awk -F= '/COREOS_PRIVATE_IPV4/ {print $2}' /etc/environment)
     fi
 
     for REQ in "${REQUIRED[@]}"; do

--- a/kola/tests/kubernetes/setup.go
+++ b/kola/tests/kubernetes/setup.go
@@ -318,7 +318,7 @@ func runInstallScript(c cluster.TestCluster, m platform.Machine, script string, 
 var (
 	etcdConfig = conf.ContainerLinuxConfig(`
 etcd:
-  advertise_client_urls: http://{PUBLIC_IPV4}:2379
+  advertise_client_urls: http://{PRIVATE_IPV4}:2379
   listen_client_urls: http://0.0.0.0:2379
 systemd:
   units:

--- a/kola/tests/kubernetes/workerInstall.go
+++ b/kola/tests/kubernetes/workerInstall.go
@@ -2,7 +2,7 @@ package kubernetes
 
 // https://github.com/coreos/coreos-kubernetes/tree/master/multi-node/generic.
 // The only change besides paramaterizing the env vars was:
-// s/FLATCAR_PUBLIC_IP/FLATCAR_PRIVATE so this works on GCE.
+// s/COREOS_PUBLIC_IP/COREOS_PRIVATE_IPV4 so this works on GCE.
 const workerInstallScript = `#!/bin/bash
 set -e
 
@@ -43,7 +43,7 @@ function init_config {
     fi
 
     if [ -z $ADVERTISE_IP ]; then
-        export ADVERTISE_IP=$(awk -F= '/FLATCAR_PRIVATE_IPV4/ {print $2}' /etc/environment)
+        export ADVERTISE_IP=$(awk -F= '/COREOS_PRIVATE_IPV4/ {print $2}' /etc/environment)
     fi
 
     for REQ in "${REQUIRED[@]}"; do

--- a/platform/cluster.go
+++ b/platform/cluster.go
@@ -151,6 +151,10 @@ func (bc *BaseCluster) RenderUserData(userdata *conf.UserData, ignitionVars map[
 		}
 	}
 
+	if *bc.bf.AdditionalSshKeys != nil {
+		userdata = conf.AddSSHKeys(userdata, bc.bf.AdditionalSshKeys)
+	}
+
 	conf, err := userdata.Render(bc.bf.ctPlatform)
 	if err != nil {
 		return nil, err

--- a/platform/conf/conf.go
+++ b/platform/conf/conf.go
@@ -862,3 +862,10 @@ func (c *Conf) IsIgnition() bool {
 func (c *Conf) IsEmpty() bool {
 	return !c.IsIgnition() && c.cloudconfig == nil && c.script == ""
 }
+
+func AddSSHKeys(userdata *UserData, keys *[]agent.Key) *UserData {
+	for _, key := range *keys {
+		userdata = userdata.AddKey(key)
+	}
+	return userdata
+}

--- a/platform/flight.go
+++ b/platform/flight.go
@@ -34,7 +34,8 @@ type BaseFlight struct {
 	ctPlatform string
 	baseopts   *Options
 
-	agent *network.SSHAgent
+	agent             *network.SSHAgent
+	AdditionalSshKeys *[]agent.Key
 }
 
 func NewBaseFlight(opts *Options, platform Name, ctPlatform string) (*BaseFlight, error) {
@@ -57,6 +58,10 @@ func NewBaseFlightWithDialer(opts *Options, platform Name, ctPlatform string, di
 	}
 
 	return bf, nil
+}
+
+func (bf *BaseFlight) GetBaseFlight() *BaseFlight {
+	return bf
 }
 
 func (bf *BaseFlight) Name() string {

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -134,6 +134,8 @@ type Flight interface {
 	// resources.  It should log any failures; since they are not
 	// actionable, it does not return an error.
 	Destroy()
+
+	GetBaseFlight() *BaseFlight
 }
 
 // SystemdDropin is a userdata type agnostic struct representing a systemd dropin


### PR DESCRIPTION
- kola: Improve debugging abilities through SSH login  
    The tests in "kola run" used a temporary SSH key and
    directly deleted the machines after a failure.
    
    Add the same SSH key option as in "kola spawn"
    to include additional SSH keys (just "-k" is
    enough to include the agent/default SSH keys).
    Also use the option to skip machine removal as
    in "kola spawn --remove=false".

- Use the private IP because the default firewall
    rules do not allow incoming traffic on 2379 for
    the public IP.
    Also, there are no FLATCAR_*_IP* variables set up in
    /etc/environment for machines running in
    Google Compute Engine because (as with afterburn)
    the prefix is still COREOS_.