### PR TITLE
helpers/azure-*: helper scripts for manually running azure tests

### DIFF
--- a/helper-scripts/azure-prep-image.sh
+++ b/helper-scripts/azure-prep-image.sh
@@ -1,0 +1,125 @@
+#!/bin/bash -e
+#
+# Create an image from a page blob and copy it to a custom region (so as to
+# cirumvent regional CPU limitationf when running tests)
+#
+
+# dummy "az" for testing
+#function az() {
+#	echo "EXEC: az $@"
+#}
+
+function channel_to_region() {
+	local blob_name="$1"
+	local channel=$(echo "$blob_name" \
+						| sed 's/.*\(alpha\|beta\|stable\|edge\).*/\1/')
+
+	case "$channel" in
+		alpha)	echo "uksouth";;
+		beta)	echo "germanywestcentral";;
+		stable) echo "francecentral";;
+		edge)	echo "ukwest";;
+		*)		echo "ERROR: unknown channel '$channel'" >&2
+				exit 1;;
+	esac
+}
+# --
+
+function disk_from_page_blob() {
+	local blob_name="$1"
+	local name="$2"
+	local rg="$3"
+
+	local out=$(mktemp)
+	trap "rm -f $out" EXIT
+
+	az disk create --name "$name" -g "$rg" \
+		--source https://$rg.blob.core.windows.net/publish/"$blob_name".vhd \
+		> "$out"
+	
+	# print disk id
+	cat "$out" | jq -r '.id'
+
+	rm -f "$out"
+	trap - EXIT
+}
+# --
+
+function image_from_disk() {
+	local name="$1"
+	local rg="$2"
+	local disk_id="$3"
+
+	az image create -g $rg --name "$name" \
+						   --source "$disk_id" --os-type linux
+}
+# --
+
+function copy_to_region() {
+	local name="$1"
+	local rg="$2"
+	local dest_rg="$3"
+	local dest_region="$4"
+
+	az image copy --source-resource-group $rg \
+				  --source-object-name "$name" \
+				  --target-location "$dest_region" \
+				  --target-resource-group "$dest_rg" \
+				  --cleanup
+}
+# --
+
+function cleanup() {
+	local disk_id="$1"
+	local rg="$2"
+	local name="$3"
+	az disk delete --no-wait --yes --ids "$disk_id"
+	az image delete -g "$rg" --name "$name"
+}
+# --
+
+function main() {
+	local rg="flatcar"
+
+	local blob_name="$1"
+	[ -z "$blob_name" ] && {
+			echo
+			echo "Usage: $0 <page-blob-name-without-vhd-suffix>"
+			echo ""
+			echo "		e.g."
+			echo "		$0 flatcar-linux-2430.0.0-alpha"
+			echo ""
+			exit 1
+	}
+
+	local image_name="$blob_name-release-testing"
+
+	local dest_region="$(channel_to_region $blob_name)"
+	local dest_rg="flatcar-release-testing-$dest_region"
+
+	echo
+	echo "Creating VM disk image $image_name from page blob $blob_name"
+	echo " in resource group $rg"
+	echo " and storing it in rg $dest_rg in region $dest_region."
+	echo
+	
+	echo " #### 1. Creating disk from page blob"
+	local disk_id=$(disk_from_page_blob "$blob_name" "$image_name" "$rg")
+	echo " ----> Generated disk with ID $disk_id"
+	
+	echo " #### 2. Creating image from disk"
+	image_from_disk "$image_name" "$rg" "$disk_id"
+
+	echo " #### 3. Copying image to rg $dest_rg in region $dest_region"
+	copy_to_region "$image_name" "$rg" "$dest_rg" "$dest_region"
+
+	echo " #### 4. Cleanup: deleting disk + image in source region"
+	cleanup "$disk_id" "$rg" "$image_name"
+
+	echo " ====> All done."
+}
+# --
+
+if [ "$(basename $0)" = "azure-prep-image.sh" ] ; then
+	main $@
+fi

--- a/helper-scripts/azure-run-kola.sh
+++ b/helper-scripts/azure-run-kola.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+function list_all_images() {
+	local rg_pattern="$1"
+	for rg in $(az group list | jq -r '.[].name' | grep "$rg_pattern"); do
+		az image list -g "$rg" | jq -r '.[].id'
+	done
+}
+# --
+
+function run_test() {
+	local image="$1"
+	local name="$2"
+	local location="$3"
+	local parallel="$4"
+
+	bin/kola run -d --platform azure --azure-disk-uri $image \
+			  --azure-location $location --parallel $parallel \
+		| tee -a $name.log
+}
+# --
+
+function main() {
+
+	# for channel_to_region()
+	source "$(dirname $BASH_SOURCE[0])/azure-prep-image.sh"
+
+	local rg_pattern="flatcar-release-testing"
+	local parallel=1
+
+	images=$(list_all_images "$rg_pattern")
+
+	echo " #### Running kola tests for images:"
+	for i in $images; do
+		echo " --> $i"
+	done
+	echo
+
+	exit
+
+	for i in $images; do
+		local name="$(basename $i)"
+		local region="$(channel_to_region $name)"
+		echo "#############################################"
+		echo " Running tests for $name"
+		echo "---------------------------------------------"
+		run_test "$i" "$name" "$region" "$parallel"
+	done
+}
+# --
+
+if [ "$(basename $0)" = "azure-run-kola.sh" ] ; then
+	main $@
+fi

--- a/kola/tests/kubernetes/controllerInstall.go
+++ b/kola/tests/kubernetes/controllerInstall.go
@@ -2,7 +2,7 @@ package kubernetes
 
 // https://github.com/coreos/coreos-kubernetes/tree/master/multi-node/generic.
 // The only change besides paramaterizing the env vars was:
-// s/FLATCAR_PUBLIC_IP/FLATCAR_PRIVATE so this works on GCE.
+// s/COREOS_PUBLIC_IP/COREOS_PRIVATE_IPV4 so this works on GCE.
 const controllerInstallScript = `#!/bin/bash
 set -e
 
@@ -54,7 +54,7 @@ function init_config {
     fi
 
     if [ -z $ADVERTISE_IP ]; then
-        export ADVERTISE_IP=$(awk -F= '/FLATCAR_PRIVATE_IPV4/ {print $2}' /etc/environment)
+        export ADVERTISE_IP=$(awk -F= '/COREOS_PRIVATE_IPV4/ {print $2}' /etc/environment)
     fi
 
     for REQ in "${REQUIRED[@]}"; do

--- a/kola/tests/kubernetes/setup.go
+++ b/kola/tests/kubernetes/setup.go
@@ -318,7 +318,7 @@ func runInstallScript(c cluster.TestCluster, m platform.Machine, script string, 
 var (
 	etcdConfig = conf.ContainerLinuxConfig(`
 etcd:
-  advertise_client_urls: http://{PUBLIC_IPV4}:2379
+  advertise_client_urls: http://{PRIVATE_IPV4}:2379
   listen_client_urls: http://0.0.0.0:2379
 systemd:
   units:

--- a/kola/tests/kubernetes/workerInstall.go
+++ b/kola/tests/kubernetes/workerInstall.go
@@ -2,7 +2,7 @@ package kubernetes
 
 // https://github.com/coreos/coreos-kubernetes/tree/master/multi-node/generic.
 // The only change besides paramaterizing the env vars was:
-// s/FLATCAR_PUBLIC_IP/FLATCAR_PRIVATE so this works on GCE.
+// s/COREOS_PUBLIC_IP/COREOS_PRIVATE_IPV4 so this works on GCE.
 const workerInstallScript = `#!/bin/bash
 set -e
 
@@ -43,7 +43,7 @@ function init_config {
     fi
 
     if [ -z $ADVERTISE_IP ]; then
-        export ADVERTISE_IP=$(awk -F= '/FLATCAR_PRIVATE_IPV4/ {print $2}' /etc/environment)
+        export ADVERTISE_IP=$(awk -F= '/COREOS_PRIVATE_IPV4/ {print $2}' /etc/environment)
     fi
 
     for REQ in "${REQUIRED[@]}"; do

--- a/kola/tests/misc/network.go
+++ b/kola/tests/misc/network.go
@@ -104,6 +104,12 @@ NextProcess:
 		pid, process := pidProgramParts[0], pidProgramParts[1]
 
 		for _, expected := range expectedListeners {
+			// netstat uses 19 chars max to display "<PID>/<process name>"
+			//  so we need to truncate the expected string accordingly
+			trunc_len := 19 - (len(pid) + len("/"))
+			if len(expected.process) > trunc_len {
+				expected.process = expected.process[0:trunc_len]
+			}
 			if strings.HasPrefix(proto, expected.protocol) && // allow expected tcp to match tcp6
 				expected.port == port &&
 				expected.process == process {

--- a/kola/tests/misc/network.go
+++ b/kola/tests/misc/network.go
@@ -132,10 +132,10 @@ NextProcess:
 
 func NetworkListeners(c cluster.TestCluster) {
 	expectedListeners := []listener{
-		{"tcp", "22", "systemd"},          // ssh
-		{"tcp", "10010", "containerd"},    // containerd
-		{"udp", "68", "systemd-network"},  // dhcp6-client
-		{"udp", "546", "systemd-network"}, // bootpc
+		{"tcp", "22", "systemd"},           // ssh
+		{"tcp", "10010", "containerd"},     // containerd
+		{"udp", "68", "systemd-networkd"},  // dhcp6-client
+		{"udp", "546", "systemd-networkd"}, // bootpc
 	}
 	checkList := func() error {
 		return checkListeners(c, expectedListeners)

--- a/platform/cluster.go
+++ b/platform/cluster.go
@@ -151,6 +151,10 @@ func (bc *BaseCluster) RenderUserData(userdata *conf.UserData, ignitionVars map[
 		}
 	}
 
+	if *bc.bf.AdditionalSshKeys != nil {
+		userdata = conf.AddSSHKeys(userdata, bc.bf.AdditionalSshKeys)
+	}
+
 	conf, err := userdata.Render(bc.bf.ctPlatform)
 	if err != nil {
 		return nil, err

--- a/platform/conf/conf.go
+++ b/platform/conf/conf.go
@@ -862,3 +862,10 @@ func (c *Conf) IsIgnition() bool {
 func (c *Conf) IsEmpty() bool {
 	return !c.IsIgnition() && c.cloudconfig == nil && c.script == ""
 }
+
+func AddSSHKeys(userdata *UserData, keys *[]agent.Key) *UserData {
+	for _, key := range *keys {
+		userdata = userdata.AddKey(key)
+	}
+	return userdata
+}

--- a/platform/flight.go
+++ b/platform/flight.go
@@ -34,7 +34,8 @@ type BaseFlight struct {
 	ctPlatform string
 	baseopts   *Options
 
-	agent *network.SSHAgent
+	agent             *network.SSHAgent
+	AdditionalSshKeys *[]agent.Key
 }
 
 func NewBaseFlight(opts *Options, platform Name, ctPlatform string) (*BaseFlight, error) {
@@ -57,6 +58,10 @@ func NewBaseFlightWithDialer(opts *Options, platform Name, ctPlatform string, di
 	}
 
 	return bf, nil
+}
+
+func (bf *BaseFlight) GetBaseFlight() *BaseFlight {
+	return bf
 }
 
 func (bf *BaseFlight) Name() string {

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -134,6 +134,8 @@ type Flight interface {
 	// resources.  It should log any failures; since they are not
 	// actionable, it does not return an error.
 	Destroy()
+
+	GetBaseFlight() *BaseFlight
 }
 
 // SystemdDropin is a userdata type agnostic struct representing a systemd dropin


### PR DESCRIPTION
This commit adds 2 helper scripts for manually running tests
on Azure.

1.  azure-prep-image.sh: prepare an azure image from a page blob
     for use with the run-kola script.
2.  azure-run-kola.sh: run kola tests on all images of an azure
     resource group.

The first script can be used to prepare images (for edge, alpha,
beta, and stable) of a release and copy those into separate
test resource groups, each in a different region.

The second script would then run tests on all images of all
test resource groups that match a predefined prefix, covering all
regions that have test images..

After testing concluded the resource group can be deleted e.g.
via the Azure web interface.

Signed-off-by: Thilo Fromm <thilo@kinvolk.io>