### PR TITLE
Fix nil pointer deref for additional SSH keys

### DIFF
--- a/platform/cluster.go
+++ b/platform/cluster.go
@@ -151,7 +151,7 @@ func (bc *BaseCluster) RenderUserData(userdata *conf.UserData, ignitionVars map[
 		}
 	}
 
-	if *bc.bf.AdditionalSshKeys != nil {
+	if bc.bf.AdditionalSshKeys != nil && *bc.bf.AdditionalSshKeys != nil {
 		userdata = conf.AddSSHKeys(userdata, bc.bf.AdditionalSshKeys)
 	}
 


### PR DESCRIPTION
When a Flight was created not being part of
"kola run" the pointer to additional SSH keys
can be nil.
Check against nil before dereferencing it.