### PR TITLE
kola: skip Docker torcx tests in case of Edge channel

### DIFF
--- a/kola/tests/docker/torcx_docker_flag.go
+++ b/kola/tests/docker/torcx_docker_flag.go
@@ -15,8 +15,11 @@
 package docker
 
 import (
+	"fmt"
 	"regexp"
+	"strings"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/coreos/mantle/kola/cluster"
 	"github.com/coreos/mantle/kola/register"
 	"github.com/coreos/mantle/platform"
@@ -57,6 +60,16 @@ write_files:
 func dockerTorcxFlagFile(c cluster.TestCluster) {
 	m := c.Machines()[0]
 
+	// Skip the test in case of Edge, e.g. "xxxx.99.z"
+	ver := strings.Split(string(c.MustSSH(m, "grep ^VERSION_ID= /etc/os-release")), "=")[1]
+	semver, err := parseCLVersion(ver)
+	if err != nil {
+		c.Fatalf("cannot parse Flatcar version: %v", err)
+	}
+	if semver.Minor == int64(99) {
+		c.Skipf("skipping tests for Edge %s", semver.String())
+	}
+
 	// flag=yes
 	checkTorcxDockerVersions(c, m, `^1\.12$`, `^1\.12\.`)
 
@@ -71,6 +84,16 @@ func dockerTorcxFlagFile(c cluster.TestCluster) {
 
 func dockerTorcxFlagFileCloudConfig(c cluster.TestCluster) {
 	m := c.Machines()[0]
+
+	// Skip the test in case of Edge, e.g. "xxxx.99.z"
+	ver := strings.Split(string(c.MustSSH(m, "grep ^VERSION_ID= /etc/os-release")), "=")[1]
+	semver, err := parseCLVersion(ver)
+	if err != nil {
+		c.Fatalf("cannot parse Flatcar version: %v", err)
+	}
+	if semver.Minor == int64(99) {
+		c.Skipf("skipping tests for Edge %s", semver.String())
+	}
 
 	// cloudinit runs after torcx
 	if err := m.Reboot(); err != nil {
@@ -91,4 +114,13 @@ func checkTorcxDockerVersions(c cluster.TestCluster, m platform.Machine, expecte
 	if !regexp.MustCompile(expectedVerRE).MatchString(ver) {
 		c.Errorf("version %s did not match %q", ver, expectedVerRE)
 	}
+}
+
+func parseCLVersion(input string) (*semver.Version, error) {
+	version, err := semver.NewVersion(input)
+	if err != nil {
+		return nil, fmt.Errorf("parsing os-release semver: %v", err)
+	}
+
+	return version, nil
 }


### PR DESCRIPTION
Since the docker 1.12 profile was removed in Edge, many kola tests started to fail to run, because of the missing docker 1.12 profile. Ideally we should be able to make a different set of profiles for each channel. Unfortunately the current Jenkins pipeline is not able to do that. It takes into account only flatcar-master branch.

To work around the issue, read directly a version from `/etc/os-release` to detect if the image is Edge. If the semver's minor version is 99, then it means Edge, so skip the tests.

Note, the code is only a quick-and-dirty approach. In the future, we should create a generic way to make channel names available for individual tests.