### PR TITLE
kola network.go: fix cl.network.listeners proc truncate

### DIFF
--- a/kola/tests/misc/network.go
+++ b/kola/tests/misc/network.go
@@ -104,6 +104,12 @@ NextProcess:
 		pid, process := pidProgramParts[0], pidProgramParts[1]
 
 		for _, expected := range expectedListeners {
+			// netstat uses 19 chars max to display "<PID>/<process name>"
+			//  so we need to truncate the expected string accordingly
+			trunc_len := 19 - (len(pid) + len("/"))
+			if len(expected.process) > trunc_len {
+				expected.process = expected.process[0:trunc_len]
+			}
 			if strings.HasPrefix(proto, expected.protocol) && // allow expected tcp to match tcp6
 				expected.port == port &&
 				expected.process == process {

--- a/kola/tests/misc/network.go
+++ b/kola/tests/misc/network.go
@@ -132,10 +132,10 @@ NextProcess:
 
 func NetworkListeners(c cluster.TestCluster) {
 	expectedListeners := []listener{
-		{"tcp", "22", "systemd"},          // ssh
-		{"tcp", "10010", "containerd"},    // containerd
-		{"udp", "68", "systemd-network"},  // dhcp6-client
-		{"udp", "546", "systemd-network"}, // bootpc
+		{"tcp", "22", "systemd"},           // ssh
+		{"tcp", "10010", "containerd"},     // containerd
+		{"udp", "68", "systemd-networkd"},  // dhcp6-client
+		{"udp", "546", "systemd-networkd"}, // bootpc
 	}
 	checkList := func() error {
 		return checkListeners(c, expectedListeners)


### PR DESCRIPTION
The test cl.network.listeners checks for active listener sockets.
It uses `netstat -plutn` to list listeners which may truncate the
program name. Since the output is compared to predefined strings
the test may fail if the combination of PID, "/", and program
name exceeds 19 characters.

This change truncates the expected string to the constraints lined
out above, which fixes the test.

To reproduce the error, run this test e.g. on Azure, where it
reproducibly fails because the PID of systemd-networkd has
4 digits:

```
bin/kola run cl.network.listeners --platform azure --azure-disk-uri <flatcar-image-URI> --azure-location <location-of-image>
```

For testing, the following URI / location may be used (transient, images will be removed eventually):
```
Image URI: /subscriptions/d38033ba-ec21-470c-96cf-4c6db9658d8b/resourceGroups/flatcar-release-testing-francecentral/providers/Microsoft.Compute/images/flatcar-linux-2345.3.0-stable-release-testing-francecentral
location: francecentral
```

Currently the test fails with:
```
=== RUN   cl.network.listeners
--- FAIL: cl.network.listeners (581.85s)
        network.go:120: full netstat output: "Active Internet connections (only servers)\nProto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name    \ntcp6       0      0 :::22                   :::*                    LISTEN      1/systemd           \nudp        0      0 10.0.0.4:68             0.0.0.0:*                           1082/systemd-networ"
        network.go:120: full netstat output: "Active Internet connections (only servers)\nProto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name    \ntcp6       0      0 :::22                   :::*                    LISTEN      1/systemd           \nudp        0      0 10.0.0.4:68             0.0.0.0:*                           1082/systemd-networ"
        network.go:120: full netstat output: "Active Internet connections (only servers)\nProto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name    \ntcp6       0      0 :::22                   :::*                    LISTEN      1/systemd           \nudp        0      0 10.0.0.4:68             0.0.0.0:*                           1082/systemd-networ"
        network.go:138: Unexpected listener process: "udp        0      0 10.0.0.4:68             0.0.0.0:*                           1082/systemd-networ"
```

After applying the change the test succeeds:
```
=== RUN   cl.network.listeners
--- PASS: cl.network.listeners (408.91s)
```

Signed-off-by: Thilo Fromm <thilo@kinvolk.io>