### PR TITLE
Port plume/kola to v2/ARM for Azure and remove outdated steps

### DIFF
--- a/cmd/kola/kola.go
+++ b/cmd/kola/kola.go
@@ -162,6 +162,8 @@ func writeProps() error {
 	}
 	type Azure struct {
 		DiskURI   string `json:"diskUri"`
+		BlobURL   string `json:"blobUrl"`
+		ImageFile string `json:"imageFile"`
 		Publisher string `json:"publisher"`
 		Offer     string `json:"offer"`
 		Sku       string `json:"sku"`
@@ -226,6 +228,8 @@ func writeProps() error {
 		},
 		Azure: Azure{
 			DiskURI:   kola.AzureOptions.DiskURI,
+			BlobURL:   kola.AzureOptions.BlobURL,
+			ImageFile: kola.AzureOptions.ImageFile,
 			Publisher: kola.AzureOptions.Publisher,
 			Offer:     kola.AzureOptions.Offer,
 			Sku:       kola.AzureOptions.Sku,

--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -91,6 +91,8 @@ func init() {
 	// azure-specific options
 	sv(&kola.AzureOptions.AzureProfile, "azure-profile", "", "Azure profile (default \"~/"+auth.AzureProfilePath+"\")")
 	sv(&kola.AzureOptions.AzureAuthLocation, "azure-auth", "", "Azure auth location (default \"~/"+auth.AzureAuthPath+"\")")
+	sv(&kola.AzureOptions.BlobURL, "azure-blob-url", "", "Azure source page blob to be copied from a public/SAS URL, recommended way (from \"plume pre-release\" or \"ore azure upload-blob-arm\")")
+	sv(&kola.AzureOptions.ImageFile, "azure-image-file", "", "Azure image file (local image to upload in the temporary kola resource group)")
 	sv(&kola.AzureOptions.DiskURI, "azure-disk-uri", "", "Azure disk uri (custom images)")
 	sv(&kola.AzureOptions.Publisher, "azure-publisher", "CoreOS", "Azure image publisher (default \"CoreOS\"")
 	sv(&kola.AzureOptions.Offer, "azure-offer", "CoreOS", "Azure image offer (default \"CoreOS\"")

--- a/cmd/ore/azure/upload-blob-arm.go
+++ b/cmd/ore/azure/upload-blob-arm.go
@@ -97,16 +97,25 @@ func runUploadBlobARM(cmd *cobra.Command, args []string) {
 		plog.Fatalf("No storage service keys found")
 	}
 
+	var sas string
 	for _, k := range *kr.Keys {
 		if err := api.UploadBlob(ubo.storageacct, *k.Value, ubo.vhd, ubo.container, ubo.blob, ubo.overwrite); err != nil {
 			plog.Fatalf("Uploading blob failed: %v", err)
 		}
+		sas, err = api.SignBlob(ubo.storageacct, *k.Value, ubo.container, ubo.blob)
+		if err != nil {
+			plog.Fatalf("signing failed: %v", err)
+		}
 		break
 	}
 
+	url := api.UrlOfBlob(ubo.storageacct, ubo.container, ubo.blob).String()
+
 	err = json.NewEncoder(os.Stdout).Encode(&struct {
 		URL string
+		SAS string
 	}{
-		URL: fmt.Sprintf("https://%s.blob.core.windows.net/%s/%s", ubo.storageacct, ubo.container, ubo.blob),
+		URL: url,
+		SAS: sas,
 	})
 }

--- a/cmd/plume/containerlinux.go
+++ b/cmd/plume/containerlinux.go
@@ -34,8 +34,7 @@ var (
 	awsBoards         = []string{"amd64-usr", "arm64-usr"}
 	azureEnvironments = []azureEnvironmentSpec{
 		azureEnvironmentSpec{
-			SubscriptionName:     "AzureCloud",
-			AdditionalContainers: []string{"pre-publish"},
+			SubscriptionName: "AzureCloud",
 		},
 	}
 	awsPartitions = []awsPartitionSpec{
@@ -78,6 +77,7 @@ var (
 				Offer:             "Flatcar",
 				Image:             "flatcar_production_azure_image.vhd.bz2",
 				StorageAccount:    "flatcar",
+				ResourceGroup:     "flatcar",
 				Container:         "publish",
 				Environments:      azureEnvironments,
 				Label:             "Flatcar Alpha",
@@ -103,6 +103,7 @@ var (
 				Offer:             "Flatcar",
 				Image:             "flatcar_production_azure_image.vhd.bz2",
 				StorageAccount:    "flatcar",
+				ResourceGroup:     "flatcar",
 				Container:         "publish",
 				Environments:      azureEnvironments,
 				Label:             "Flatcar Beta",
@@ -128,6 +129,7 @@ var (
 				Offer:             "Flatcar",
 				Image:             "flatcar_production_azure_image.vhd.bz2",
 				StorageAccount:    "flatcar",
+				ResourceGroup:     "flatcar",
 				Container:         "publish",
 				Environments:      azureEnvironments,
 				Label:             "Flatcar Stable",
@@ -153,6 +155,7 @@ var (
 				Offer:             "Flatcar",
 				Image:             "flatcar_production_azure_image.vhd.bz2",
 				StorageAccount:    "flatcar",
+				ResourceGroup:     "flatcar",
 				Container:         "publish",
 				Environments:      azureEnvironments,
 				Label:             "Flatcar Edge",

--- a/cmd/plume/types.go
+++ b/cmd/plume/types.go
@@ -34,14 +34,14 @@ type gceSpec struct {
 }
 
 type azureEnvironmentSpec struct {
-	SubscriptionName     string   // Name of subscription in Azure profile
-	AdditionalContainers []string // Extra containers to upload the disk image to
+	SubscriptionName string // Name of subscription in Azure profile
 }
 
 type azureSpec struct {
 	Offer          string                 // Azure offer name
 	Image          string                 // File name of image source
 	StorageAccount string                 // Storage account to use for image uploads in each environment
+	ResourceGroup  string                 // Resource Group to use for blobs in each environment
 	Container      string                 // Container to hold the disk image in each environment
 	Environments   []azureEnvironmentSpec // Azure environments to upload to
 

--- a/platform/api/azure/api.go
+++ b/platform/api/azure/api.go
@@ -172,6 +172,10 @@ func randomName(prefix string) string {
 	return fmt.Sprintf("%s-%x", prefix, b)
 }
 
+func (a *API) GetOpts() *Options {
+	return a.opts
+}
+
 func (a *API) GC(gracePeriod time.Duration) error {
 	durationAgo := time.Now().Add(-1 * gracePeriod)
 

--- a/platform/api/azure/image.go
+++ b/platform/api/azure/image.go
@@ -92,14 +92,14 @@ func (a *API) CreateImage(name, resourceGroup, blobURI string) (compute.Image, e
 	return a.imgClient.Get(resourceGroup, name, "")
 }
 
-// resolveImage is used to ensure that either a Version or DiskURI
+// resolveImage is used to ensure that either a Version or DiskURI/BlobURL/ImageFile
 // are provided present for a run. If neither is given via arguments
 // it attempts to parse the Version from the version.txt in the Sku's
 // release bucket.
 func (a *API) resolveImage() error {
 	// immediately return if the version has been set or if the channel
 	// is not set via the Sku (this happens in ore)
-	if a.opts.DiskURI != "" || a.opts.Version != "" || a.opts.Sku == "" {
+	if a.opts.DiskURI != "" || a.opts.BlobURL != "" || a.opts.ImageFile != "" || a.opts.Version != "" || a.opts.Sku == "" {
 		return nil
 	}
 

--- a/platform/api/azure/options.go
+++ b/platform/api/azure/options.go
@@ -25,6 +25,8 @@ type Options struct {
 	AzureAuthLocation string
 	AzureSubscription string
 
+	BlobURL   string
+	ImageFile string
 	DiskURI   string
 	Publisher string
 	Offer     string


### PR DESCRIPTION
This uses the v2 API for plume because the classic OS images
    are not working with kola and we also migrated the storage
    account.
    The prerelease step is also simplified because the
    image is not necessary for the followed release step as it
    directly works with page blobs.
    For kola tests we better create an image where needed.
    The "pre-publish" container is not used anymore.
    Instead of "sharing" the image we now create a SAS URL
    which we need to specify in the SKU. This step remains
    manual for now.
    In addition, there are new command line flags for testing plume.
    For kola the options --azure-image-file and --azure-blob-url
    were added to directly upload a file into the temporary resource
    group or to copy a blob from another storage location into the
    temporary resource group (the blob may be uploaded before via
    "plume pre-release" or "ore azure upload-blob-arm".
