### PR TITLE
Azure: Add list permissions to SAS URL

### DIFF
--- a/platform/api/azure/storage_mit.go
+++ b/platform/api/azure/storage_mit.go
@@ -268,7 +268,7 @@ func (a *API) SignBlob(storageaccount, storagekey, container, blob string) (stri
 
 	bsc := sc.GetBlobService()
 
-	return bsc.GetBlobSASURI(container, blob, time.Date(2099, time.December, 31, 23, 59, 59, 0, time.UTC), "r")
+	return bsc.GetBlobSASURI(container, blob, time.Date(2099, time.December, 31, 23, 59, 59, 0, time.UTC), "rl") // TODO: Migrate to new API version
 }
 
 func (a *API) CopyBlob(storageaccount, storagekey, container, targetBlob, sourceBlob string) error {


### PR DESCRIPTION
According to the SAS URL requirements in
https://docs.microsoft.com/en-us/azure/marketplace/cloud-partner-portal/virtual-machine/cpp-get-sas-uri#verify-the-sas-uri
and
https://docs.microsoft.com/en-us/azure/marketplace/cloud-partner-portal/virtual-machine/cpp-common-sas-url-issues
we should grant List permissions.
Maybe this is still not enough and we need to update
to a newer API to get the correct start/
expiry time formats.