### PR TITLE
plume pre-release: Add flag to force image upload

### DIFF
--- a/cmd/ore/aws/upload.go
+++ b/cmd/ore/aws/upload.go
@@ -207,7 +207,7 @@ func runUpload(cmd *cobra.Command, args []string) error {
 	s3ObjectPath := strings.TrimPrefix(s3URL.Path, "/")
 
 	if uploadForce {
-		API.RemoveImage(amiName, s3BucketName, s3ObjectPath)
+		API.RemoveImage(amiName, s3BucketName, s3ObjectPath, nil)
 	}
 
 	// if no snapshot was specified, check for an existing one or a

--- a/platform/api/azure/storage_mit.go
+++ b/platform/api/azure/storage_mit.go
@@ -285,3 +285,14 @@ func (a *API) CopyBlob(storageaccount, storagekey, container, targetBlob, source
 
 	return bsc.CopyBlob(container, targetBlob, sourceBlob)
 }
+
+func (a *API) DeleteBlob(storageaccount, storagekey, container, blob string) error {
+	sc, err := storage.NewClient(storageaccount, storagekey, a.opts.StorageEndpointSuffix, storage.DefaultAPIVersion, true)
+	if err != nil {
+		return err
+	}
+
+	bsc := sc.GetBlobService()
+
+	return bsc.DeleteBlob(container, blob, nil)
+}


### PR DESCRIPTION
If images with the same name existed, they were reused by plume.
This meant that a fix for a release would not be uploaded because
it had the same image name.
Add a flag to force image uploading by removing any existing AMIs/
snapshots with the same name.