### PR TITLE
kola: fix unit names for system-cloudinit service

### DIFF
--- a/kola/tests/ignition/passwd.go
+++ b/kola/tests/ignition/passwd.go
@@ -33,7 +33,7 @@ func init() {
 		             "ignitionVersion": 1,
 		             "systemd": {
 		               "units": [{
-		                 "name": "system-cloudinit@usr-share-coreos-developer_data.service",
+		                 "name": "system-cloudinit@usr-share-flatcar-developer_data.service",
 		                 "mask": true
 		               }]
 		             },
@@ -61,7 +61,7 @@ func init() {
 		             "ignition": { "version": "2.0.0" },
 		             "systemd": {
 		               "units": [{
-		                 "name": "system-cloudinit@usr-share-coreos-developer_data.service",
+		                 "name": "system-cloudinit@usr-share-flatcar-developer_data.service",
 		                 "mask": true
 		               }]
 		             },
@@ -83,7 +83,7 @@ func init() {
 		             "ignition": { "version": "3.0.0" },
 		             "systemd": {
 		               "units": [{
-		                 "name": "system-cloudinit@usr-share-coreos-developer_data.service",
+		                 "name": "system-cloudinit@usr-share-flatcar-developer_data.service",
 		                 "mask": true
 		               }]
 		             },
@@ -111,7 +111,7 @@ func init() {
 		             "ignitionVersion": 1,
 		             "systemd": {
 		               "units": [{
-		                 "name": "system-cloudinit@usr-share-coreos-developer_data.service",
+		                 "name": "system-cloudinit@usr-share-flatcar-developer_data.service",
 		                 "mask": true
 		               }]
 		             },
@@ -145,7 +145,7 @@ func init() {
 		             "ignition": { "version": "2.0.0" },
 		             "systemd": {
 		               "units": [{
-		                 "name": "system-cloudinit@usr-share-coreos-developer_data.service",
+		                 "name": "system-cloudinit@usr-share-flatcar-developer_data.service",
 		                 "mask": true
 		               }]
 		             },


### PR DESCRIPTION
For ignition to successfully change password hashes, the unit `system-cloudinit@user-share-flatcar-developer_data.service` must be masked.
Otherwise, the unit will run again cloudinit, which will change the user password again, and the ignition tests will fail like this:

```
--- FAIL: cl.ignition.v1.users (19.77s)
        passwd.go:321: "core" wasn't correctly created:
got "core":"$1$q5c1evy8$i6MbDRMPJeY28scalaUrM/", expected "core":"foobar"
```

We need to fix unit names, from `coreos` to `flatcar`, so that the correct unit can be masked.
