### PR TITLE
kola run: Accept a list of glob patterns, kola list: Platform/distro filters with glob patterns

### DIFF
--- a/kola/harness.go
+++ b/kola/harness.go
@@ -188,7 +188,7 @@ func NewFlight(pltfrm string) (flight platform.Flight, err error) {
 	return
 }
 
-func filterTests(tests map[string]*register.Test, pattern, pltfrm string, version semver.Version) (map[string]*register.Test, error) {
+func FilterTests(tests map[string]*register.Test, pattern, pltfrm string, version semver.Version) (map[string]*register.Test, error) {
 	r := make(map[string]*register.Test)
 
 	checkPlatforms := []string{pltfrm}
@@ -304,7 +304,7 @@ func RunTests(pattern, pltfrm, outputDir string, sshKeys *[]agent.Key, remove bo
 	// 2) glob is an exact match which means minVersion will be ignored
 	//    either way
 	// 3) the provided torcx flag is wrong
-	tests, err := filterTests(register.Tests, pattern, pltfrm, semver.Version{})
+	tests, err := FilterTests(register.Tests, pattern, pltfrm, semver.Version{})
 	if err != nil {
 		plog.Fatal(err)
 	}
@@ -348,7 +348,7 @@ func RunTests(pattern, pltfrm, outputDir string, sshKeys *[]agent.Key, remove bo
 		versionStr = version.String()
 
 		// one more filter pass now that we know real version
-		tests, err = filterTests(tests, pattern, pltfrm, *version)
+		tests, err = FilterTests(tests, pattern, pltfrm, *version)
 		if err != nil {
 			plog.Fatal(err)
 		}


### PR DESCRIPTION
- kola list: Platform/distro filters with glob patterns
  The "kola run" command accepts a glob pattern to limit which tests are run.
  To test a pattern before running a test, add a filter option to
  "kola list" to filter the list of known tests by platform and distro,
  and if wanted with a glob pattern to see its effect.
- kola run: Accept a list of glob patterns  
    Glob patterns are matching like the shell expands a glob pattern.
    This does not allow to test against two names that don't share a
    substring. On the shell this is solved by having two glob arguments.
    Allow multiple glob patterns to be specified as arguments to handle
    the cases where the tests don't share a substring but we want to run
    exactly those tests.
