### PR TITLE
cl.network.listeners: add systemd-timesyncd

### DIFF
--- a/kola/tests/misc/network.go
+++ b/kola/tests/misc/network.go
@@ -111,7 +111,7 @@ NextProcess:
 				expected.process = expected.process[0:trunc_len]
 			}
 			if strings.HasPrefix(proto, expected.protocol) && // allow expected tcp to match tcp6
-				expected.port == port &&
+				(expected.port == "*" || expected.port == port) &&
 				expected.process == process {
 				// matches expected process
 				continue NextProcess
@@ -136,6 +136,7 @@ func NetworkListeners(c cluster.TestCluster) {
 		{"tcp", "10010", "containerd"},     // containerd
 		{"udp", "68", "systemd-networkd"},  // dhcp6-client
 		{"udp", "546", "systemd-networkd"}, // bootpc
+		{"udp", "*", "systemd-timesyncd"},  // NTP client (random client ports)
 	}
 	checkList := func() error {
 		return checkListeners(c, expectedListeners)


### PR DESCRIPTION
# Add systemd-timesyncd to list of expected listener processes in `cl.network.listeners` test

This change adds `systemd-timesyncd` to the list of expected listener processes in the test `cl.network.listeners`. 

`systemd-timesyncd` is an NTP client service which will not listen constantly but only run occasionally, binding to random UDP client ports when running. Therefore, the test does not check for a port number.

# How to use

- check out: `gh pr checkout 76`
- build: `make -j`
- run qemu test (needs a Flatcar qemu image: `sudo ./kola run cl.network.listeners --debug --platform qemu --qemu-bios=bios-256k.bin --qemu-image flatcar_production_qemu_image.img`

# Testing done
- Ran the above commands and validated the change does not break `cl.network.listeners`
- Did not explicitly validate against a running `systemd-timesyncd` as the NTP client only runs occasionally, for a short period of time. We've seen the test fail during release testing though, so I'll closely monitor release testing logs to make sure the test does not fail because of `systemd-timesyncd` in the future.