### PR TITLE
Fix AWS AMI architecture and name

### DIFF
--- a/cmd/plume/prerelease.go
+++ b/cmd/plume/prerelease.go
@@ -574,7 +574,7 @@ func awsUploadToPartition(spec *channelSpec, part *awsPartitionSpec, imagePath s
 
 	plog.Printf("Creating AMIs from %v...", snapshot.SnapshotID)
 
-	hvmImageID, err := api.CreateHVMImage(snapshot.SnapshotID, aws.ContainerLinuxDiskSizeGiB, imageName+AmiNameArchTag()+"-hvm", imageDescription+" (HVM)")
+	hvmImageID, err := api.CreateHVMImage(snapshot.SnapshotID, aws.ContainerLinuxDiskSizeGiB, imageName+"-hvm", imageDescription+" (HVM)")
 	if err != nil {
 		return nil, fmt.Errorf("unable to create HVM image: %v", err)
 	}

--- a/cmd/plume/prerelease.go
+++ b/cmd/plume/prerelease.go
@@ -574,7 +574,12 @@ func awsUploadToPartition(spec *channelSpec, part *awsPartitionSpec, imagePath s
 
 	plog.Printf("Creating AMIs from %v...", snapshot.SnapshotID)
 
-	hvmImageID, err := api.CreateHVMImage(snapshot.SnapshotID, aws.ContainerLinuxDiskSizeGiB, imageName+"-hvm", imageDescription+" (HVM)")
+	amiArch, err := aws.AmiArchForBoard(specBoard)
+	if err != nil {
+		return nil, fmt.Errorf("could not get architecture for board: %v", err)
+	}
+
+	hvmImageID, err := api.CreateHVMImage(snapshot.SnapshotID, aws.ContainerLinuxDiskSizeGiB, imageName+"-hvm", imageDescription+" (HVM)", amiArch)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create HVM image: %v", err)
 	}

--- a/cmd/plume/release.go
+++ b/cmd/plume/release.go
@@ -484,7 +484,7 @@ func doAWS(ctx context.Context, client *http.Client, src *storage.Bucket, spec *
 					}
 				}
 			}
-			publish(imageName + AmiNameArchTag() + "-hvm")
+			publish(imageName + "-hvm")
 		}
 	}
 }


### PR DESCRIPTION
- plume/ore: Derive AWS AMI architecture from board
    Only x86_64 was always used as architecture for AWS AMIs.
    Set the correct AMI architecture depending on the board.
- plume: Remove duplicate architecture tag from AWS image name
    The architecture tag was first added to the image before the -hvm suffix
    and then later added to the image metadata.
    Since the metadata is used for the image name, we ended up with
    adding the architecture tag twice for the pending release:
    Flatcar-edge-2466.99.0-arm64-arm64-hvm
    Do not append the architecture tag before the -hvm suffix.

# How to use

Used in Jenkins `os/(pre)release`.


# Testing done

None