### PR TITLE
kola: increase cgroup memory limit to 30MB

### DIFF
--- a/kola/tests/docker/docker.go
+++ b/kola/tests/docker/docker.go
@@ -261,7 +261,7 @@ func dockerResources(c cluster.TestCluster) {
 	// ref https://docs.docker.com/engine/reference/run/#runtime-constraints-on-resources
 	for _, dockerCmd := range []string{
 		// must set memory when setting memory-swap
-		dCmd("--memory=20m --memory-swap=20m"),
+		dCmd("--memory=30m --memory-swap=30m"),
 		dCmd("--memory-reservation=10m"),
 		dCmd("--kernel-memory=10m"),
 		dCmd("--cpu-shares=100"),
@@ -277,7 +277,7 @@ func dockerResources(c cluster.TestCluster) {
 		//dCmd("--device-write-bps=/dev/vda:1kb"),
 		//dCmd("--device-read-iops=/dev/vda:10"),
 		//dCmd("--device-write-iops=/dev/vda:10"),
-		dCmd("--memory=20m --oom-kill-disable=true"),
+		dCmd("--memory=30m --oom-kill-disable=true"),
 		dCmd("--memory-swappiness=50"),
 		dCmd("--shm-size=1m"),
 	} {


### PR DESCRIPTION
Since runc 1.0-rc7 or newer, memory consumption of runc has increased, so Docker has not been able to run containers with cgroup memory limit > 10MB.
The memory consumption issues were improved since 1.0-rc8, but not completely. 
That's why some docker tests have failed with the following messages.

```
--- FAIL: docker.base/resources (34.69s)
        cluster.go:117: /run/torcx/bin/docker: Error response from daemon: cannot start a stopped process: unknown.
        docker.go:302: [0] failed to run "docker run --rm --memory=20m --memory-swap=20m sleep sleep 0.2": output: "" status: "Process exited with status 125"
```

We need to increase the limit from to 30MB, to make the tests work again.

## Testing done

On an AWS instance (m5.large, 8GB mem):

```
tmpdir=$(mktemp -d); cd $tmpdir; echo -e "FROM scratch\nCOPY . /" > Dockerfile; b=$(which sleep); libs=$(sudo ldd $b | grep -o /lib'[^ ]*' | sort -u); sudo rsync -av --relative --copy-links $b $libs ./; sudo docker build -t sleep .

while true ; do docker run --name=test1 --rm --memory=30m --memory-swap=30m sleep sleep 0.2; done
while true ; do docker run --name=test1 --rm --memory=30m --oom-kill-disable=true sleep sleep 0.2; done
```
