### PR TITLE
kola: Add argument to enable channel based testing

### DIFF
--- a/cmd/kola/kola.go
+++ b/cmd/kola/kola.go
@@ -294,7 +294,9 @@ func runList(cmd *cobra.Command, args []string) {
 			test.ExcludePlatforms,
 			test.Architectures,
 			test.Distros,
-			test.ExcludeDistros}
+			test.ExcludeDistros,
+			test.Channels,
+			test.ExcludeChannels}
 		item.updateValues()
 		testlist = append(testlist, item)
 	}
@@ -306,7 +308,7 @@ func runList(cmd *cobra.Command, args []string) {
 	if !listJSON {
 		var w = tabwriter.NewWriter(os.Stdout, 0, 8, 0, '\t', 0)
 
-		fmt.Fprintln(w, "Test Name\tPlatforms\tArchitectures\tDistributions")
+		fmt.Fprintln(w, "Test Name\tPlatforms\tArchitectures\tDistributions\tChannels")
 		fmt.Fprintln(w, "\t")
 		for _, item := range testlist {
 			fmt.Fprintf(w, "%v\n", item)
@@ -329,6 +331,8 @@ type item struct {
 	Architectures    []string
 	Distros          []string
 	ExcludeDistros   []string `json:"-"`
+	Channels         []string
+	ExcludeChannels  []string `json:"-"`
 }
 
 func (i *item) updateValues() {
@@ -366,8 +370,9 @@ func (i *item) updateValues() {
 	i.Platforms = buildItems(i.Platforms, i.ExcludePlatforms, kolaPlatforms)
 	i.Architectures = buildItems(i.Architectures, nil, kolaArchitectures)
 	i.Distros = buildItems(i.Distros, i.ExcludeDistros, kolaDistros)
+	i.Channels = buildItems(i.Channels, i.ExcludeChannels, kolaChannels)
 }
 
 func (i item) String() string {
-	return fmt.Sprintf("%v\t%v\t%v\t%v", i.Name, i.Platforms, i.Architectures, i.Distros)
+	return fmt.Sprintf("%v\t%v\t%v\t%v\t%v", i.Name, i.Platforms, i.Architectures, i.Distros, i.Channels)
 }

--- a/cmd/kola/kola.go
+++ b/cmd/kola/kola.go
@@ -130,7 +130,7 @@ func runRun(cmd *cobra.Command, args []string) {
 	} else {
 		sshKeys = nil
 	}
-	runErr := kola.RunTests(patterns, kolaPlatform, outputDir, &sshKeys, runRemove)
+	runErr := kola.RunTests(patterns, kolaChannel, kolaPlatform, outputDir, &sshKeys, runRemove)
 
 	// needs to be after RunTests() because harness empties the directory
 	if err := writeProps(); err != nil {
@@ -278,7 +278,7 @@ func runList(cmd *cobra.Command, args []string) {
 			patterns = []string{"*"} // run all tests by default
 		}
 		var err error
-		tests, err = kola.FilterTests(register.Tests, patterns, kolaPlatform, semver.Version{})
+		tests, err = kola.FilterTests(register.Tests, patterns, kolaChannel, kolaPlatform, semver.Version{})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "filtering error: %v\n", err)
 			os.Exit(1)

--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -35,10 +35,12 @@ import (
 var (
 	outputDir          string
 	kolaPlatform       string
+	kolaChannel        string
 	defaultTargetBoard = sdk.DefaultBoard()
 	kolaArchitectures  = []string{"amd64"}
 	kolaPlatforms      = []string{"aws", "azure", "do", "esx", "gce", "openstack", "packet", "qemu", "qemu-unpriv"}
 	kolaDistros        = []string{"cl", "fcos", "rhcos"}
+	kolaChannels       = []string{"alpha", "beta", "stable", "edge"}
 	kolaDefaultImages  = map[string]string{
 		"amd64-usr": sdk.BuildRoot() + "/images/amd64-usr/latest/flatcar_production_image.bin",
 		"arm64-usr": sdk.BuildRoot() + "/images/arm64-usr/latest/flatcar_production_image.bin",
@@ -64,6 +66,7 @@ func init() {
 	sv(&outputDir, "output-dir", "", "Temporary output directory for test data and logs")
 	sv(&kola.TorcxManifestFile, "torcx-manifest", "", "Path to a torcx manifest that should be made available to tests")
 	root.PersistentFlags().StringVarP(&kolaPlatform, "platform", "p", "qemu", "VM platform: "+strings.Join(kolaPlatforms, ", "))
+	root.PersistentFlags().StringVarP(&kolaChannel, "channel", "c", "stable", "Channel: "+strings.Join(kolaChannels, ", "))
 	root.PersistentFlags().StringVarP(&kola.Options.Distribution, "distro", "b", "cl", "Distribution: "+strings.Join(kolaDistros, ", "))
 	root.PersistentFlags().IntVarP(&kola.TestParallelism, "parallel", "j", 1, "number of tests to run in parallel")
 	sv(&kola.TAPFile, "tapfile", "", "file to write TAP results to")
@@ -168,6 +171,10 @@ func syncOptions() error {
 	}
 
 	if err := validateOption("platform", kolaPlatform, kolaPlatforms); err != nil {
+		return err
+	}
+
+	if err := validateOption("channel", kolaChannel, kolaChannels); err != nil {
 		return err
 	}
 

--- a/kola/register/register.go
+++ b/kola/register/register.go
@@ -56,6 +56,8 @@ type Test struct {
 	ExcludePlatforms []string // blacklist of platforms to ignore -- defaults to none
 	Distros          []string // whitelist of distributions to run test against -- defaults to all
 	ExcludeDistros   []string // blacklist of distributions to ignore -- defaults to none
+	Channels         []string // whitelist of channels to run test against -- defaults to all
+	ExcludeChannels  []string // blacklist of channels to ignore -- defaults to all
 	Architectures    []string // whitelist of machine architectures supported -- defaults to all
 	Flags            []Flag   // special-case options for this test
 

--- a/kola/register/register.go
+++ b/kola/register/register.go
@@ -57,7 +57,7 @@ type Test struct {
 	Distros          []string // whitelist of distributions to run test against -- defaults to all
 	ExcludeDistros   []string // blacklist of distributions to ignore -- defaults to none
 	Channels         []string // whitelist of channels to run test against -- defaults to all
-	ExcludeChannels  []string // blacklist of channels to ignore -- defaults to all
+	ExcludeChannels  []string // blacklist of channels to ignore -- defaults to none
 	Architectures    []string // whitelist of machine architectures supported -- defaults to all
 	Flags            []Flag   // special-case options for this test
 


### PR DESCRIPTION
Add argument to enable channel based testing

This PR adds the argument `--channel` to enable channel based testing, which
means you can populate the Channel property in kola tests and kola would decide to
include/exclude the test based on which channel it is running.

This PR also output the channels when the list subcommand is run both with or without `--json`


# How to use

`./bin/kola run [--channel <channel>]`
`./bin/kola list [--channel <channel>]`


# Testing done

Both the outputs are snipped.

```
$ ./bin/kola list
Test Name                                       Platforms       Architectures   Distributions   Channels

cl.basic                                        [all]                                                   [all]   [cl]            [all]
cl.cloudinit.basic                              [aws azure do esx gce openstack packet qemu]            [all]   [cl]            [all]
cl.cloudinit.script                             [aws azure do esx gce openstack packet qemu]            [all]   [cl]            [all]
cl.disk.raid.data                               [all]                                                   [all]   [cl]            [all]
cl.disk.raid.root                               [qemu]                                                  [all]   [cl]            [all]
cl.etcd-member.discovery                        [all]                                                   [all]   [cl]            [all]
cl.etcd-member.etcdctlv3                        [all]                                                   [all]   [cl]            [all]
cl.etcd-member.v2-backup-restore                [aws azure do gce openstack packet qemu qemu-unpriv]    [all]   [cl]            [all]
cl.filesystem                                   [all]                                                   [all]   [cl]            [all]
cl.flannel.udp                                  [all]                                                   [all]   [cl]            [all]
cl.flannel.vxlan                                [all]                                                   [all]   [cl]            [all]
cl.ignition.misc.empty                          [aws azure do gce openstack packet qemu-unpriv]         [all]   [cl]            [all]
cl.ignition.v1.btrfsroot                        [all]                                                   [all]   [cl]            [all]
cl.ignition.v1.ext4root                         [all]                                                   [all]   [cl]            [all]
cl.ignition.v1.groups                           [all]                                                   [all]   [cl]            [all]
cl.ignition.v1.noop                             [aws azure do gce packet qemu-unpriv]                   [all]   [cl]            [all]
cl.ignition.v1.once                             [all]                                                   [all]   [cl]            [all]
cl.ignition.v1.sethostname                      [aws do esx gce openstack packet qemu qemu-unpriv]      [all]   [cl]            [all]
cl.ignition.v1.ssh.key                          [aws azure do esx gce openstack packet qemu-unpriv]     [all]   [cl]            [all]
cl.ignition.v1.users                            [all]                                                   [all]   [cl]            [all]
cl.ignition.v1.xfsroot                          [all]                                                   [all]   [cl]            [all]
cl.ignition.v2.btrfsroot                        [all]                                                   [all]   [cl]            [all]
cl.ignition.v2.ext4root                         [all]                                                   [all]   [cl]            [all]
cl.ignition.v2.noop                             [aws azure do gce packet qemu-unpriv]                   [all]   [cl]            [all]
cl.ignition.v2.users                            [all]                                                   [all]   [cl]            [all]
cl.ignition.v2.xfsroot                          [all]                                                   [all]   [cl]            [all]
cl.ignition.v2_1.ext4checkexisting              [all]                                                   [all]   [cl]            [all]
cl.ignition.v2_1.swap                           [all]                                                   [all]   [cl]            [all]
cl.ignition.v2_1.vfat                           [all]                                                   [all]   [cl]            [all]
cl.install.cloudinit                            [aws do esx gce openstack packet qemu qemu-unpriv]      [all]   [cl]            [all]
cl.internet                                     [all]                                                   [all]   [cl]            [all]
cl.locksmith.cluster                            [all]                                                   [all]   [cl]            [all]
cl.metadata.aws                                 [aws]                                                   [all]   [cl]            [all]
cl.metadata.azure                               [azure]                                                 [all]   [cl]            [all]
cl.metadata.packet                              [packet]                                                [all]   [cl]            [all]
cl.network.initramfs.second-boot                [aws azure esx gce openstack packet qemu qemu-unpriv]   [all]   [cl]            [all]
cl.network.listeners                            [aws azure do esx gce openstack packet qemu]            [all]   [cl]            [all]
cl.network.listeners.legacy                     [aws azure do esx gce openstack packet qemu]            [all]   [cl]            [all]
cl.omaha.ping                                   [qemu]                                                  [all]   [cl]            [all]
cl.rkt.etcd3                                    [all]                                                   [all]   [cl]            [all]
cl.toolbox.dnf-install                          [all]                                                   [all]   [cl]            [all]
cl.update.badverity                             [all]                                                   [all]   [cl]            [all]
cl.update.grubnop                               [aws azure do esx gce openstack packet qemu]            [amd64] [cl]            [all]
cl.update.payload                               [all]                                                   [all]   [cl]            [all]
cl.update.reboot                                [all]                                                   [all]   [cl]            [all]
cl.users.shells                                 [aws azure do esx openstack packet qemu qemu-unpriv]    [all]   [cl]            [all]
cl.verity                                       [all]                                                   [all]   [cl]            [all]
coreos.auth.verify                              [all]                                                   [all]   [cl fcos rhcos] [all]
coreos.ignition.groups                          [all]                                                   [all]   [cl fcos rhcos] [all]
coreos.ignition.once                            [all]                                                   [all]   [cl fcos rhcos] [all]
```

```
$ ./bin/kola list --json
[
        {
                "Name": "cl.basic",
                "Platforms": [
                        "aws",
                        "azure",
                        "do",
                        "esx",
                        "gce",
                        "openstack",
                        "packet",
                        "qemu",
                        "qemu-unpriv"
                ],
                "Architectures": [
                        "amd64"
                ],
                "Distros": [
                        "cl"
                ],
                "Channels": [
                        "alpha",
                        "beta",
                        "stable",
                        "edge"
                ]
        },
        {
                "Name": "cl.cloudinit.basic",
                "Platforms": [
                        "aws",
                        "azure",
                        "do",
                        "esx",
                        "gce",
                        "openstack",
                        "packet",
                        "qemu"
                ],
                "Architectures": [
                        "amd64"
                ],
                "Distros": [
                        "cl"
                ],
                "Channels": [
                        "alpha",
                        "beta",
                        "stable",
                        "edge"
                ]
        },
```