### PR TITLE
kola: default to 2GB instance size on digitalocean

### DIFF
--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -106,7 +106,7 @@ func init() {
 	sv(&kola.DOOptions.Profile, "do-profile", "", "DigitalOcean profile (default \"default\")")
 	sv(&kola.DOOptions.AccessToken, "do-token", "", "DigitalOcean access token (overrides config file)")
 	sv(&kola.DOOptions.Region, "do-region", "sfo2", "DigitalOcean region slug")
-	sv(&kola.DOOptions.Size, "do-size", "1gb", "DigitalOcean size slug")
+	sv(&kola.DOOptions.Size, "do-size", "s-1vcpu-2gb", "DigitalOcean size slug")
 	sv(&kola.DOOptions.Image, "do-image", "alpha", "DigitalOcean image ID, {alpha, beta, stable}, or user image name")
 
 	// esx-specific options


### PR DESCRIPTION
# Default to s-1vcpu-2gb instance for kola on digital ocean

Kola currently uses an instance size with 1GB RAM on DigitalOcean. This leads to docker tests from the `docker.base` suite to fail from resource exhaustion (OOM kills).

This change makes `kola` use DO's `s-1vcpu-2gb` instance size by default.

# How to use
```
./ore do create-image --config-file ~/.do/token.json --name=kola-test-2gb --url=https://storage.googleapis.com/flatcar-jenkins/edge/boards/amd64-usr/2466.99.0/flatcar_production_digitalocean_image.bin.bz2
./kola run --basename=kola-test-2gb --do-config-file ~/.do/token.json --do-image=kola-test-2gb --platform=do docker.base
./ore do delete-image --name=kola-test-2gb --config-file ~/.do/token.json
```

# Testing done

Ran the above commands, tests passed.