### PR TITLE
Skip old Kubernetes test for Alpha/Edge channels

### DIFF
--- a/kola/tests/kubernetes/basic.go
+++ b/kola/tests/kubernetes/basic.go
@@ -46,11 +46,12 @@ func init() {
 			}
 
 			register.Register(&register.Test{
-				Name:        "google.kubernetes.basic." + r + "." + t,
-				Run:         f,
-				ClusterSize: 0,
-				Platforms:   []string{"gce"},
-				Distros:     []string{"cl"},
+				Name:            "google.kubernetes.basic." + r + "." + t,
+				Run:             f,
+				ClusterSize:     0,
+				Platforms:       []string{"gce"},
+				Distros:         []string{"cl"},
+				ExcludeChannels: []string{"alpha", "edge"},
 			})
 		}
 	}


### PR DESCRIPTION
The test `google.kubernetes.basic.docker.v1.3.4_coreos.0` is not compatible
with Docker 19.06.
See https://github.com/flatcar-linux/Flatcar/issues/79#issuecomment-613619548
for details.

# Testing done

The following output is empty as wanted:

```
./kola list --filter --platform gce --channel edge | grep google.kubernetes.basic.docker.v1.3.4_coreos.0
```