### PR TITLE
Packet: Always report error when provisioning failed

### DIFF
--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -66,7 +66,7 @@ func init() {
 	sv(&outputDir, "output-dir", "", "Temporary output directory for test data and logs")
 	sv(&kola.TorcxManifestFile, "torcx-manifest", "", "Path to a torcx manifest that should be made available to tests")
 	root.PersistentFlags().StringVarP(&kolaPlatform, "platform", "p", "qemu", "VM platform: "+strings.Join(kolaPlatforms, ", "))
-	root.PersistentFlags().StringVarP(&kolaChannel, "channel", "c", "stable", "Channel: "+strings.Join(kolaChannels, ", "))
+	root.PersistentFlags().StringVarP(&kolaChannel, "channel", "", "stable", "Channel: "+strings.Join(kolaChannels, ", "))
 	root.PersistentFlags().StringVarP(&kola.Options.Distribution, "distro", "b", "cl", "Distribution: "+strings.Join(kolaDistros, ", "))
 	root.PersistentFlags().IntVarP(&kola.TestParallelism, "parallel", "j", 1, "number of tests to run in parallel")
 	sv(&kola.TAPFile, "tapfile", "", "file to write TAP results to")


### PR DESCRIPTION
The retry loop relies on having access to the last error. This error value
was shadowed in some cases which caused the error not be be logged and the
function to report a nil error when the maximal number of retries was reached.

Never shadow the error variable with local error variables in for/if scopes so
that the error value is assigned to the functions error variable.

# How to use

Run kola tests for arm64 on Packet.

# Testing done

```
./kola spawn -d -k --board=arm64-usr --gce-json-key gce-token.json --packet-facility=sjc1 --packet-project=ABC --packet-storage-url=gs://flatcar-jenkins/mantle/packet --platform=packet --packet-api-key=XXX --packet-installer-image-base-url http://8.8.8.8/404
```
Provisioning should fail 3 times and kola spawn should end with an error.
A faster way to fail provision early is `--packet-plan xyz`.
Without `--packet-installer-image-base-url http://8.8.8.8/404` or `--packet-plan xyz` it should eventually work to get a shell on a machine.