### PR TITLE
kola: Exclude Docker torcx tests for Edge Channel

### DIFF
--- a/kola/tests/docker/torcx_docker_flag.go
+++ b/kola/tests/docker/torcx_docker_flag.go
@@ -37,7 +37,8 @@ storage:
         inline: yes
       mode: 0644
 `),
-		Distros: []string{"cl"},
+		Distros:         []string{"cl"},
+		ExcludeChannels: []string{"edge"},
 	})
 	register.Register(&register.Test{
 		Run:         dockerTorcxFlagFileCloudConfig,
@@ -51,6 +52,7 @@ write_files:
 `),
 		Distros:          []string{"cl"},
 		ExcludePlatforms: []string{"qemu-unpriv"},
+		ExcludeChannels:  []string{"edge"},
 	})
 }
 


### PR DESCRIPTION
# kola: Exclude Docker torcx tests for Edge Channel

#61 implements a hacky way to exclude the Docker torcx tests for the edge channel. Now that we have a proper way, I've reverted the change and added the necessary changes.


# How to use

./kola run --channel edge
./kola run --channel alpha

# Testing done

I've just built the code to see if it builds
