### PR TITLE
Switch to Hyperkube v1.14+.

### DIFF
--- a/kola/tests/kubernetes/basic.go
+++ b/kola/tests/kubernetes/basic.go
@@ -28,7 +28,9 @@ import (
 
 // register a separate test for each version tag
 var basicTags = []string{
-	"v1.3.4_coreos.0",
+	"v1.14.10",
+	"v1.16.8",
+	"v1.18.0",
 }
 
 // regester each tag once per runtime

--- a/kola/tests/kubernetes/basic.go
+++ b/kola/tests/kubernetes/basic.go
@@ -48,12 +48,11 @@ func init() {
 			}
 
 			register.Register(&register.Test{
-				Name:            "google.kubernetes.basic." + r + "." + t,
-				Run:             f,
-				ClusterSize:     0,
-				Platforms:       []string{"gce"},
-				Distros:         []string{"cl"},
-				ExcludeChannels: []string{"alpha", "edge"},
+				Name:        "google.kubernetes.basic." + r + "." + t,
+				Run:         f,
+				ClusterSize: 0,
+				Platforms:   []string{"gce"},
+				Distros:     []string{"cl"},
 			})
 		}
 	}


### PR DESCRIPTION
# Adapt our existing kubernetes test to newer versions

Starting from Docker 19.03, we need a newer version of Kubernetes or our deployment doesn't work. So we switch to testing newer k8s versions.

This includes updating quite a few Kubernetes flags that were deprecated since the old version we were using, to use the new names and formats (some flags were renamed, others had to be moved to config files, others don't exist anymore). Supporting different Kubernetes versions also means adding some conditional behavior for commands that changed along the way.

This commit also switches to the hyperkube images provided by gcr.io instead of the ones provided by quay.io, as those were discontinued. To get this to work we need to prepend the ACI with docker:// and set the --insecure-options=image option (See coreos/coreos-kubernetes#583)

It also updates the environment variables in the service files to the non-deprecated ones wanted by kubelet-wrapper.

And it adds a few plog messages while setting up to make the kola output more helpful.

# How to run

* Build kola with this change
* `bin/kola run --basename=new-kube --gce-image=marga-test-2466-0-0 --gce-json-key=gce-service-account.json --parallel=4 --platform=gce -d -k --remove=false --torcx-manifest=torcx_manifest.json google.kubernetes.basic.docker.v1.16.8 google.kubernetes.basic.docker.v1.18.0 google.kubernetes.basic.docker.v1.14.10`

# Testing done

I've run the command listed above and it passed for all three versions of Hyperkube (after a lot of tweaking the setup...)

Fixes: flatcar-linux/Flatcar#79