### PR TITLE
plume: flag out upload for unauth calls

### DIFF
--- a/cmd/plume/prerelease.go
+++ b/cmd/plume/prerelease.go
@@ -748,7 +748,7 @@ func awsPreRelease(ctx context.Context, client *http.Client, src *storage.Bucket
 		}
 	}
 
-	if selectedDistro == "cl" {
+	if selectedDistro == "cl" && gceJSONKeyFile != "none" {
 		if err := awsUploadAmiLists(ctx, src, spec, &amis); err != nil {
 			return fmt.Errorf("uploading AMI IDs: %v", err)
 		}


### PR DESCRIPTION
# flag out upload for unauth calls

In case that `gceJSONKeyFile` is not set, don't upalod AMI list

# How to use

[ describe what reviewers need to do in order to validate this PR ]


# Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]
