### PR TITLE
ESX: Add kola option to work without a base VM

### DIFF
--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -117,6 +117,7 @@ func init() {
 	sv(&kola.ESXOptions.Server, "esx-server", "", "ESX server")
 	sv(&kola.ESXOptions.Profile, "esx-profile", "", "ESX profile (default \"default\")")
 	sv(&kola.ESXOptions.BaseVMName, "esx-base-vm", "", "ESX base VM name")
+	sv(&kola.ESXOptions.OvaPath, "esx-ova-path", "", "ESX VM image to upload instead of using the base VM (build with: ./image_to_vm.sh --format=vmware_ova ...)")
 
 	// gce-specific options
 	sv(&kola.GCEOptions.Image, "gce-image", "projects/coreos-cloud/global/images/family/coreos-alpha", "GCE image, full api endpoints names are accepted if resource is in a different project")


### PR DESCRIPTION
Cloning from a base VM to spare the image upload is not supported by
the free version of ESXi. It is also useful for "kola spawn" to work
without a base VM.
Add an option to create a VM directly from an uploaded image.
The userdata is set over guestinfo variables instead of modifying the
default values of the OVF metadata.

# How to use/testing done

Create a VM on a [Packet.net ESXi server](https://www.packet.com/resources/guides/esxi/):
```
./kola spawn --platform esx --esx-config-file esx.json --esx-ova-path flatcar_production_vmware_ova.ova  -d
```
By default this give an error because the VM expects DHCP to be set up which isn't the case in the default Packet.net ESXi configuration. To work around this I used a custom userdata in kola to set a password and log in to the VM over the VGA console through the web UI.