### PR TITLE
cmd/plume: Add a developer channel

### DIFF
--- a/cmd/plume/containerlinux.go
+++ b/cmd/plume/containerlinux.go
@@ -77,6 +77,15 @@ var (
 				"cn-northwest-1",
 			},
 		},
+		"developer": awsPartitionSpec{
+			Name:         "AWS Developer",
+			Profile:      "default",
+			Bucket:       "flatcar-prod-ami-import-eu-central-1",
+			BucketRegion: "eu-central-1",
+			Regions: []string{
+				"eu-central-1",
+			},
+		},
 	}
 
 	specs = map[string]channelSpec{
@@ -129,6 +138,19 @@ var (
 				"publish",
 				"Flatcar Edge",
 				"The Edge channel closely tracks current development work and is released frequently. The newest versions of the Linux kernel, systemd, and other components will be available for testing.",
+			),
+			AWS: newAWSSpec(),
+		},
+		"developer": channelSpec{
+			BaseURL:      "gs://flatcar-jenkins/developer/boards",
+			Boards:       []string{"amd64-usr", "arm64-usr"},
+			Destinations: []storageSpec{},
+			GCE:          gceSpec{},
+			Azure: newAzureSpec(
+				azureEnvironments,
+				"developer",
+				"Flatcar Developer Channel",
+				"The Developer Channel is used for internal test builds.",
 			),
 			AWS: newAWSSpec(),
 		},
@@ -250,11 +272,15 @@ func ChannelSpec() channelSpec {
 		spec.AWS = awsSpec{}
 	}
 
+	// For the developer channel, use the developer partition
+	if specChannel == "developer" {
+		specAwsPartition = "developer"
+	}
+
 	awsPartition, awsPartitionOk := awsPartitions[specAwsPartition]
 	if !awsPartitionOk {
 		plog.Fatalf("Unknown AWS Partition: %s", specAwsPartition)
 	}
-
 	spec.AWS.Partitions = []awsPartitionSpec{awsPartition}
 
 	return spec

--- a/cmd/plume/containerlinux.go
+++ b/cmd/plume/containerlinux.go
@@ -78,109 +78,87 @@ var (
 			},
 		},
 	}
+
 	specs = map[string]channelSpec{
 		"alpha": channelSpec{
 			BaseURL:      "gs://flatcar-jenkins/alpha/boards",
 			Boards:       []string{"amd64-usr", "arm64-usr"},
 			Destinations: []storageSpec{},
 			GCE:          gceSpec{},
-			Azure: azureSpec{
-				Offer:             "Flatcar",
-				Image:             "flatcar_production_azure_image.vhd.bz2",
-				StorageAccount:    "flatcar",
-				ResourceGroup:     "flatcar",
-				Container:         "publish",
-				Environments:      azureEnvironments,
-				Label:             "Flatcar Alpha",
-				Description:       "The Alpha channel closely tracks current development work and is released frequently. The newest versions of the Linux kernel, systemd, and other components will be available for testing.",
-				RecommendedVMSize: "Medium",
-				IconURI:           "coreos-globe-color-lg-100px.png",
-				SmallIconURI:      "coreos-globe-color-lg-45px.png",
-			},
-			AWS: awsSpec{
-				BaseName:        "Flatcar",
-				BaseDescription: "Flatcar Container Linux",
-				Prefix:          "flatcar_production_ami_",
-				Image:           "flatcar_production_ami_vmdk_image.vmdk.bz2",
-			},
+			Azure: newAzureSpec(
+				azureEnvironments,
+				"publish",
+				"Flatcar Alpha",
+				"The Alpha channel closely tracks current development work and is released frequently. The newest versions of the Linux kernel, systemd, and other components will be available for testing.",
+			),
+			AWS: newAWSSpec(),
 		},
 		"beta": channelSpec{
 			BaseURL:      "gs://flatcar-jenkins/beta/boards",
 			Boards:       []string{"amd64-usr"},
 			Destinations: []storageSpec{},
 			GCE:          gceSpec{},
-			Azure: azureSpec{
-				Offer:             "Flatcar",
-				Image:             "flatcar_production_azure_image.vhd.bz2",
-				StorageAccount:    "flatcar",
-				ResourceGroup:     "flatcar",
-				Container:         "publish",
-				Environments:      azureEnvironments,
-				Label:             "Flatcar Beta",
-				Description:       "The Beta channel consists of promoted Alpha releases. Mix a few beta machines into your production clusters to catch any bugs specific to your hardware or configuration.",
-				RecommendedVMSize: "Medium",
-				IconURI:           "coreos-globe-color-lg-100px.png",
-				SmallIconURI:      "coreos-globe-color-lg-45px.png",
-			},
-			AWS: awsSpec{
-				BaseName:        "Flatcar",
-				BaseDescription: "Flatcar Container Linux",
-				Prefix:          "flatcar_production_ami_",
-				Image:           "flatcar_production_ami_vmdk_image.vmdk.bz2",
-			},
+			Azure: newAzureSpec(
+				azureEnvironments,
+				"publish",
+				"Flatcar Beta",
+				"The Beta channel consists of promoted Alpha releases. Mix a few beta machines into your production clusters to catch any bugs specific to your hardware or configuration.",
+			),
+			AWS: newAWSSpec(),
 		},
 		"stable": channelSpec{
 			BaseURL:      "gs://flatcar-jenkins/stable/boards",
 			Boards:       []string{"amd64-usr"},
 			Destinations: []storageSpec{},
 			GCE:          gceSpec{},
-			Azure: azureSpec{
-				Offer:             "Flatcar",
-				Image:             "flatcar_production_azure_image.vhd.bz2",
-				StorageAccount:    "flatcar",
-				ResourceGroup:     "flatcar",
-				Container:         "publish",
-				Environments:      azureEnvironments,
-				Label:             "Flatcar Stable",
-				Description:       "The Stable channel should be used by production clusters. Versions of CoreOS Container Linux are battle-tested within the Beta and Alpha channels before being promoted.",
-				RecommendedVMSize: "Medium",
-				IconURI:           "coreos-globe-color-lg-100px.png",
-				SmallIconURI:      "coreos-globe-color-lg-45px.png",
-			},
-			AWS: awsSpec{
-				BaseName:        "Flatcar",
-				BaseDescription: "Flatcar Container Linux",
-				Prefix:          "flatcar_production_ami_",
-				Image:           "flatcar_production_ami_vmdk_image.vmdk.bz2",
-			},
+			Azure: newAzureSpec(
+				azureEnvironments,
+				"publish",
+				"Flatcar Stable",
+				"The Stable channel should be used by production clusters. Versions of CoreOS Container Linux are battle-tested within the Beta and Alpha channels before being promoted.",
+			),
+			AWS: newAWSSpec(),
 		},
 		"edge": channelSpec{
 			BaseURL:      "gs://flatcar-jenkins/edge/boards",
 			Boards:       []string{"amd64-usr", "arm64-usr"},
 			Destinations: []storageSpec{},
 			GCE:          gceSpec{},
-			Azure: azureSpec{
-				Offer:             "Flatcar",
-				Image:             "flatcar_production_azure_image.vhd.bz2",
-				StorageAccount:    "flatcar",
-				ResourceGroup:     "flatcar",
-				Container:         "publish",
-				Environments:      azureEnvironments,
-				Label:             "Flatcar Edge",
-				Description:       "The Edge channel closely tracks current development work and is released frequently. The newest versions of the Linux kernel, systemd, and other components will be available for testing.",
-				RecommendedVMSize: "Medium",
-				IconURI:           "coreos-globe-color-lg-100px.png",
-				SmallIconURI:      "coreos-globe-color-lg-45px.png",
-			},
-			AWS: awsSpec{
-				BaseName:        "Flatcar",
-				BaseDescription: "Flatcar Container Linux",
-				Prefix:          "flatcar_production_ami_",
-				Image:           "flatcar_production_ami_vmdk_image.vmdk.bz2",
-			},
+			Azure: newAzureSpec(
+				azureEnvironments,
+				"publish",
+				"Flatcar Edge",
+				"The Edge channel closely tracks current development work and is released frequently. The newest versions of the Linux kernel, systemd, and other components will be available for testing.",
+			),
+			AWS: newAWSSpec(),
 		},
 	}
 )
+
+func newAzureSpec(environments []azureEnvironmentSpec, container, label, description string) azureSpec {
+	return azureSpec{
+		Offer:             "Flatcar",
+		Image:             "flatcar_production_azure_image.vhd.bz2",
+		StorageAccount:    "flatcar",
+		ResourceGroup:     "flatcar",
+		Container:         container,
+		Environments:      environments,
+		Label:             label,
+		Description:       description,
+		RecommendedVMSize: "Medium",
+		IconURI:           "coreos-globe-color-lg-100px.png",
+		SmallIconURI:      "coreos-globe-color-lg-45px.png",
+	}
+}
+
+func newAWSSpec() awsSpec {
+	return awsSpec{
+		BaseName:        "Flatcar",
+		BaseDescription: "Flatcar Container Linux",
+		Prefix:          "flatcar_production_ami_",
+		Image:           "flatcar_production_ami_vmdk_image.vmdk.bz2",
+	}
+}
 
 func AddSpecFlags(flags *pflag.FlagSet) {
 	board := sdk.DefaultBoard()

--- a/cmd/plume/prerelease.go
+++ b/cmd/plume/prerelease.go
@@ -614,7 +614,7 @@ func awsUploadToPartition(spec *channelSpec, part *awsPartitionSpec, imagePath s
 
 		amis := map[string]string{}
 		if len(destRegions) > 0 {
-			plog.Printf("Replicating AMI %v...", imageID)
+			plog.Printf("Replicating AMI %v to %d regions...", imageID, len(destRegions))
 			amis, err = api.CopyImage(imageID, destRegions)
 			if err != nil {
 				return nil, fmt.Errorf("couldn't copy image: %v", err)


### PR DESCRIPTION
# Add a developer channel to be used on pre-release jobs

In order to enable developer builds we need to have a fully working developer channel. This adds support the necessary support to plume.
    
On AWS this channel will upload the image to only one region.

This change also re-organizes the default values for the Azure and AWS specifications, to avoid excessive copying and pasting when adding a new channel.

Needed for: kinvolk/PROJECT-flatcar-linux#294

# How to use / Testing done

I've tested this for both AWS and Azure with the following command lines:
```
bin/plume pre-release --debug --platform=aws \
--aws-credentials=/home/marga/kinvolk/.creds/aws-release-credentials \
--gce-json-key=/home/marga/kinvolk/.creds/gce-service-account.json \
--board=arm64-usr --channel=developer --version=2466.0.0 \
--write-image-list=images.json --verify-key=/home/marga/kinvolk/.creds/verify.asc

bin/plume pre-release --debug --platform=azure \
--azure-profile=/home/marga/kinvolk/.creds/azureProfile.json \
--azure-auth=/home/marga/kinvolk/.creds/azureCredentials.json \
--gce-json-key=/home/marga/kinvolk/.creds/gce-service-account.json \
--board=amd64-usr --channel=developer --version=2466.99.0 \
--write-image-list=images.json --verify-key=/home/marga/kinvolk/.creds/verify.asc
```