### PR TITLE
ore: Add option for ESX config path

### DIFF
--- a/cmd/ore/esx/esx.go
+++ b/cmd/ore/esx/esx.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/coreos/mantle/auth"
 	"github.com/coreos/mantle/cli"
 	"github.com/coreos/mantle/platform/api/esx"
 	"github.com/coreos/pkg/capnslog"
@@ -39,6 +40,7 @@ var (
 func init() {
 	ESX.PersistentFlags().StringVar(&options.Server, "server", "", "ESX server")
 	ESX.PersistentFlags().StringVar(&options.Profile, "profile", "", "Profile")
+	ESX.PersistentFlags().StringVar(&options.ConfigPath, "esx-config-file", "", "ESX config file (default \"~/"+auth.ESXConfigPath+"\")")
 	cli.WrapPreRun(ESX, preflightCheck)
 }
 


### PR DESCRIPTION
The default ESX config path was always used.
Add the same flag that kola also has to provide a different path.


# How to use
```
./ore esx remove-base --name kola-54ab7aa4… --esx-config-file esx.json
```
# How to test
Before:
```
./ore esx remove-base
could not create ESX client: couldn't read ESX config: open /home/…/.config/esx.json: no such file or directory
```
After:
```
./ore esx remove-base --esx-config-file /dev/null
could not create ESX client: couldn't read ESX config: EOF
```