### PR TITLE
esx: Allow to configure static IPs

### DIFF
--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -118,6 +118,12 @@ func init() {
 	sv(&kola.ESXOptions.Profile, "esx-profile", "", "ESX profile (default \"default\")")
 	sv(&kola.ESXOptions.BaseVMName, "esx-base-vm", "", "ESX base VM name")
 	sv(&kola.ESXOptions.OvaPath, "esx-ova-path", "", "ESX VM image to upload instead of using the base VM (build with: ./image_to_vm.sh --format=vmware_ova ...)")
+	root.PersistentFlags().IntVarP(&kola.ESXOptions.StaticIPs, "esx-static-ips", "", 0, "Instead of DHCP, use this amount of static IP addresses")
+	sv(&kola.ESXOptions.StaticGatewayIp, "esx-gateway", "", "Public gateway (only needed for static IP addresses)")
+	sv(&kola.ESXOptions.StaticGatewayIpPrivate, "esx-gateway-private", "", "Private gateway (only needed for static IP addresses)")
+	sv(&kola.ESXOptions.FirstStaticIp, "esx-first-static-ip", "", "First available public IP (only needed for static IP addresses)")
+	sv(&kola.ESXOptions.FirstStaticIpPrivate, "esx-first-static-ip-private", "", "First available private IP (only needed for static IP addresses)")
+	root.PersistentFlags().IntVarP(&kola.ESXOptions.StaticSubnetSize, "esx-subnet-size", "", 0, "Subnet size (only needed for static IP addresses)")
 
 	// gce-specific options
 	sv(&kola.GCEOptions.Image, "gce-image", "projects/coreos-cloud/global/images/family/coreos-alpha", "GCE image, full api endpoints names are accepted if resource is in a different project")

--- a/kola/tests/ignition/resource.go
+++ b/kola/tests/ignition/resource.go
@@ -105,7 +105,8 @@ func init() {
 			"Serve": Serve,
 		},
 		// https://github.com/coreos/bugs/issues/2205
-		ExcludePlatforms: []string{"do", "qemu-unpriv"},
+		// ESX: Currently Ignition does not support static IPs during the initramfs
+		ExcludePlatforms: []string{"esx", "do", "qemu-unpriv"},
 		Distros:          []string{"cl", "fcos", "rhcos"},
 	})
 	register.Register(&register.Test{
@@ -113,8 +114,9 @@ func init() {
 		Run:         resourceRemote,
 		ClusterSize: 1,
 		Flags:       []register.Flag{register.RequiresInternetAccess},
+		// ESX: Currently Ignition does not support static IPs during the initramfs
 		// https://github.com/coreos/bugs/issues/2205 for DO
-		ExcludePlatforms: []string{"do"},
+		ExcludePlatforms: []string{"esx", "do"},
 		UserData: conf.Ignition(`{
 		  "ignition": {
 		      "version": "2.1.0"
@@ -238,8 +240,9 @@ func init() {
 		Run:         resourceS3Versioned,
 		ClusterSize: 1,
 		Flags:       []register.Flag{register.RequiresInternetAccess},
+		// ESX: Currently Ignition does not support static IPs during the initramfs
 		// https://github.com/coreos/bugs/issues/2205 for DO
-		ExcludePlatforms: []string{"do"},
+		ExcludePlatforms: []string{"esx", "do"},
 		MinVersion:       semver.Version{Major: 1995},
 		UserData: conf.Ignition(`{
 		  "ignition": {

--- a/kola/tests/ignition/security.go
+++ b/kola/tests/ignition/security.go
@@ -77,9 +77,10 @@ func init() {
 			"TLSServe":   TLSServe,
 			"TLSServeV3": TLSServeV3,
 		},
+		// ESX: Currently Ignition does not support static IPs during the initramfs
 		// DO: https://github.com/coreos/bugs/issues/2205
 		// Packet & QEMU: https://github.com/coreos/ignition/issues/645
-		ExcludePlatforms: []string{"do", "packet", "qemu"},
+		ExcludePlatforms: []string{"esx", "do", "packet", "qemu"},
 		Distros:          []string{"cl", "fcos", "rhcos"},
 	})
 }

--- a/platform/machine/esx/machine.go
+++ b/platform/machine/esx/machine.go
@@ -31,6 +31,7 @@ type machine struct {
 	dir     string
 	journal *platform.Journal
 	console string
+	ipPair  *esx.IpPair
 }
 
 func (em *machine) ID() string {
@@ -68,6 +69,11 @@ func (em *machine) Reboot() error {
 func (em *machine) Destroy() {
 	if err := em.cluster.flight.api.TerminateDevice(em.ID()); err != nil {
 		plog.Errorf("Error terminating device %v: %v", em.ID(), err)
+	}
+
+	if em.ipPair != nil {
+		plog.Debugf("Setting static IP addresses %v and %v as available", (*em.ipPair).Public, (*em.ipPair).Private)
+		em.cluster.flight.ips <- *em.ipPair
 	}
 
 	if em.journal != nil {


### PR DESCRIPTION
- esx: Allow to configure static IPs    
    The default ESXi setup does not have a DHCP server but expects
    static IPs to be used (e.g., see https://www.packet.com/resources/guides/esxi/).
    Allocate static IPs for each machine from a number of addresses
    starting with a specific address given inside the subnet (in Packet this
    is the next IP address after the host's IP, see link above).
    A networkd configuration file is used with Ignition but cloud-config writes its
    own networkd configuration file based on the guestinfo.interface* variables.
    The coreos-metadata service uses the COREOS_CUSTOM_* variables that are known
    to the Container Linux Config Transpiler, too, and got some robustness fixes.

# How to use

```
./kola run -d --platform esx --esx-config-file esx.json --esx-ova-path flatcar_production_vmware_ova.ova  --esx-first-static-ip A.B.C.D --esx-first-static-ip-private E.F.G.H --esx-static-ips 4 --esx-gateway I.J.K.L --esx-gateway-private M.N.O.P --esx-subnet-size 29
```

Because we only have 4 static IPs, do not set `--parallel X` because kola will wait anyway until a machine terminates again and frees an IP.

# Testing done

Use an ESX server on Packet and use the gateways as visible in the network setting of the Packet web UI, and use the next IP after the server IP as available first static IPs (see link above). When the ESX server is provisioned, a /28 subnet can be specified instead of the defautl /29 but I didn' test this.
I fixed most test failures and skipped tests that rely on network connectivity in the initramfs.