### PR TITLE
cmd/plume: Move developer builds to us-west-2

### DIFF
--- a/cmd/plume/containerlinux.go
+++ b/cmd/plume/containerlinux.go
@@ -80,10 +80,10 @@ var (
 		"developer": awsPartitionSpec{
 			Name:         "AWS Developer",
 			Profile:      "default",
-			Bucket:       "flatcar-prod-ami-import-eu-central-1",
-			BucketRegion: "eu-central-1",
+			Bucket:       "flatcar-developer-ami-import-us-west-2",
+			BucketRegion: "us-west-2",
 			Regions: []string{
-				"eu-central-1",
+				"us-west-2",
 			},
 		},
 	}


### PR DESCRIPTION
The verification script in os/prerelease looks at the us-west-2 region, so put developer builds in that region instead of Europe.

For this to work, a new S3 bucket had to be created.  I've created `flatcar-developer-ami-import-us-west-2` in us-west-2 and gave it the same permissions and policies as the other bucket.

Tested this change with: `bin/plume pre-release --debug --platform=aws --aws-credentials=/home/marga/kinvolk/.creds/aws-release-credentials --gce-json-key=/home/marga/kinvolk/.creds/gce-service-account.json --board=amd64-usr --channel=developer --version=2345.3.1+jenkins2-flatcar-master-382 --write-image-list=images.json --verify-key=/home/marga/kinvolk/.creds/verify.asc`