### PR TITLE
esx: Optionally read static IP config from ESX profile

### DIFF
--- a/auth/esx.go
+++ b/auth/esx.go
@@ -27,9 +27,15 @@ const ESXConfigPath = ".config/esx.json"
 // ESXProfile represents a parsed ESX profile. This is a custom format
 // specific to Mantle.
 type ESXProfile struct {
-	Server   string `json:"server"`
-	User     string `json:"user"`
-	Password string `json:"password"`
+	Server                 string `json:"server"`
+	User                   string `json:"user"`
+	Password               string `json:"password"`
+	StaticIPs              int    `json:"static_ips,omitempty"`
+	FirstStaticIp          string `json:"first_static_ip,omitempty"`
+	FirstStaticIpPrivate   string `json:"first_static_ip_private,omitempty"`
+	StaticGatewayIp        string `json:"gateway,omitempty"`
+	StaticGatewayIpPrivate string `json:"gateway_private,omitempty"`
+	StaticSubnetSize       int    `json:"subnet_size,omitempty"`
 }
 
 // ReadESXConfig decodes a ESX config file, which is a custom format

--- a/platform/api/esx/api.go
+++ b/platform/api/esx/api.go
@@ -156,6 +156,24 @@ func New(opts *Options) (*API, error) {
 		if opts.Password == "" {
 			opts.Password = profile.Password
 		}
+		if opts.StaticIPs == 0 {
+			opts.StaticIPs = profile.StaticIPs
+		}
+		if opts.FirstStaticIp == "" {
+			opts.FirstStaticIp = profile.FirstStaticIp
+		}
+		if opts.FirstStaticIpPrivate == "" {
+			opts.FirstStaticIpPrivate = profile.FirstStaticIpPrivate
+		}
+		if opts.StaticGatewayIp == "" {
+			opts.StaticGatewayIp = profile.StaticGatewayIp
+		}
+		if opts.StaticGatewayIpPrivate == "" {
+			opts.StaticGatewayIpPrivate = profile.StaticGatewayIpPrivate
+		}
+		if opts.StaticSubnetSize == 0 {
+			opts.StaticSubnetSize = profile.StaticSubnetSize
+		}
 	}
 
 	esxUrl := fmt.Sprintf("%s:%s@%s", url.QueryEscape(opts.User), url.QueryEscape(opts.Password), opts.Server)

--- a/platform/api/esx/api.go
+++ b/platform/api/esx/api.go
@@ -365,6 +365,12 @@ func (a *API) CreateDevice(name string, conf *conf.Conf, ips *IpPair) (*ESXMachi
 	folder := folders.VmFolder
 
 	var vm *object.VirtualMachine
+	defer func() {
+		// Only works if err was not shadowed like "if { foo, err := bar }"
+		if err != nil && vm != nil {
+			_ = a.deleteDevice(vm)
+		}
+	}()
 	if a.options.OvaPath != "" {
 		plog.Debugf("Uploading image from %q", a.options.OvaPath)
 		arch, cisr, err := a.buildCreateImportSpecRequest(name, a.options.OvaPath, defaults.finder, defaults.network, defaults.resourcePool, defaults.datastore)
@@ -504,7 +510,8 @@ func (a *API) CreateDevice(name string, conf *conf.Conf, ips *IpPair) (*ESXMachi
 	}
 
 	plog.Debugf("Getting machine")
-	mach, err := a.getMachine(vm)
+	var mach *ESXMachine
+	mach, err = a.getMachine(vm)
 	if err != nil {
 		return nil, fmt.Errorf("getting machine info: %v", err)
 	}

--- a/platform/machine/esx/cluster.go
+++ b/platform/machine/esx/cluster.go
@@ -96,6 +96,10 @@ ExecStart=/usr/bin/bash -c 'echo "COREOS_CUSTOM_PRIVATE_IPV4=$(ip addr show ens1
 
 	instance, err := ec.flight.api.CreateDevice(ec.vmname(), conf, ipPairMaybe)
 	if err != nil {
+		if ipPairMaybe != nil {
+			plog.Debugf("Setting static IP addresses %v and %v as available", (*ipPairMaybe).Public, (*ipPairMaybe).Private)
+			ec.flight.ips <- *ipPairMaybe
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
- esx: Optionally read static IP config from ESX profile
    Instead of a long list of command line options, the static IP configuration
    should be part of the config file.
    The values can be left out and the command line options get preference.
- esx: Always remove created VM on error
- esx: Free static IP up when device creation failed