### PR TITLE
esx: Add ore commands to list and remove VMs by pattern

### DIFF
--- a/cmd/ore/esx/list-vms.go
+++ b/cmd/ore/esx/list-vms.go
@@ -1,0 +1,53 @@
+// Copyright 2020 Kinvolk GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package esx
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	cmdListVMs = &cobra.Command{
+		Use:   "list-vms",
+		Short: "List VMs on ESX",
+		Long: `List all names of VMs on ESX
+
+After a successful run, all names are written in one line each.
+`,
+		RunE: runListVMs,
+	}
+
+	patternToList string
+)
+
+func init() {
+	ESX.AddCommand(cmdListVMs)
+	cmdListVMs.Flags().StringVar(&patternToList, "pattern", "*", "Pattern to match for")
+}
+
+func runListVMs(cmd *cobra.Command, args []string) error {
+	names, err := API.GetDevices(patternToList)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Couldn't list VMs: %v\n", err)
+		os.Exit(1)
+	}
+	for _, name := range names {
+		fmt.Println(name)
+	}
+	return nil
+}

--- a/cmd/ore/esx/remove-vms.go
+++ b/cmd/ore/esx/remove-vms.go
@@ -1,0 +1,64 @@
+// Copyright 2020 Kinvolk GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package esx
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	cmdRemoveVMs = &cobra.Command{
+		Use:   "remove-vms",
+		Short: "Remove VMs on ESX",
+		Long: `Remove all VMs on ESX that match a pattern
+
+After a successful run, all names of deleted VMs are written in one line each.
+`,
+		RunE: runRemoveVMs,
+	}
+
+	patternToRemove string
+)
+
+func init() {
+	ESX.AddCommand(cmdRemoveVMs)
+	cmdRemoveVMs.Flags().StringVar(&patternToRemove, "pattern", "*", "Pattern that VMs to be removed should match")
+}
+
+func runRemoveVMs(cmd *cobra.Command, args []string) error {
+	names, err := API.GetDevices(patternToRemove)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Couldn't list VMs: %v\n", err)
+		os.Exit(1)
+	}
+
+	var failed bool
+	for _, name := range names {
+		err := API.TerminateDevice(name)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Couldn't delete VM %q: %v\n", name, err)
+			failed = true
+		}
+		fmt.Println(name)
+	}
+
+	if failed {
+		os.Exit(1)
+	}
+	return nil
+}

--- a/platform/api/esx/api.go
+++ b/platform/api/esx/api.go
@@ -553,6 +553,25 @@ func (a *API) CreateBaseDevice(name, ovaPath string) error {
 	return nil
 }
 
+func (a *API) GetDevices(pattern string) ([]string, error) {
+	defaults, err := a.getServerDefaults()
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get server defaults: %v", err)
+	}
+
+	vms, err := defaults.finder.VirtualMachineList(a.ctx, pattern)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't list VMs: %v", err)
+	}
+
+	// idea: add more filters with VirtualMachineRuntimeInfo
+	names := make([]string, len(vms))
+	for i, vm := range vms {
+		names[i] = vm.Name()
+	}
+	return names, nil
+}
+
 func (a *API) TerminateDevice(name string) error {
 	defaults, err := a.getServerDefaults()
 	if err != nil {


### PR DESCRIPTION
The list command for `ore` allows to see if any VMs exist on ESXi. The remove command allows to delete these VMs. Both commands take a pattern to match for (similar to shell globs).

# How to use/test

```
./ore esx --esx-config-file esx.json list-vms
kola-0df55961-a4e2-42f0-99ec-39eb21091864-117b901c07
./ore esx --esx-config-file esx.json remove-vms --pattern 'kola-*'
kola-0df55961-a4e2-42f0-99ec-39eb21091864-117b901c07
```
