### PR TITLE
kola: Skip docker.torcx-manifest-pkgs on VMware ESXi

### DIFF
--- a/kola/tests/docker/torcx_manifest_pkgs.go
+++ b/kola/tests/docker/torcx_manifest_pkgs.go
@@ -35,7 +35,8 @@ func init() {
 		Name:        "docker.torcx-manifest-pkgs",
 		Flags:       []register.Flag{register.RequiresInternetAccess}, // Downloads torcx packages
 		// https://github.com/coreos/bugs/issues/2205 for DO
-		ExcludePlatforms: []string{"do"},
+		// ESX: Currently Ignition does not support static IPs during the initramfs
+		ExcludePlatforms: []string{"esx", "do"},
 		Distros:          []string{"cl"},
 	})
 }


### PR DESCRIPTION
Our tests use a static IP which is set up after Ignition or
coreos-cloudinit ran but torcx needs it to be set up during the
initramfs already.