### PR TITLE
esx: Use 2 GiB RAM on VMware VMs to pass the docker tests

### DIFF
--- a/platform/api/esx/api.go
+++ b/platform/api/esx/api.go
@@ -497,6 +497,12 @@ func (a *API) CreateDevice(name string, conf *conf.Conf, ips *IpPair) (*ESXMachi
 		// End of hack
 	}
 
+	plog.Debugf("Setting memory to 2 GiB")
+	err = a.setMemoryMB(vm, 2048)
+	if err != nil {
+		return nil, fmt.Errorf("setting memory: %v", err)
+	}
+
 	plog.Debugf("Adding serial port for VM")
 	err = a.addSerialPort(vm)
 	if err != nil {
@@ -733,6 +739,18 @@ func networkMap(finder *find.Finder, e *ovf.Envelope) (p []types.OvfNetworkMappi
 		}
 	}
 	return
+}
+
+func (a *API) setMemoryMB(vm *object.VirtualMachine, memoryMB int64) error {
+	task, err := vm.Reconfigure(a.ctx, types.VirtualMachineConfigSpec{
+		MemoryMB: memoryMB,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	return task.Wait(a.ctx)
 }
 
 func (a *API) updateGuestVariable(vm *object.VirtualMachine, key, value string) error {


### PR DESCRIPTION
The tests docker.lib-coreos-dockerd-compat and docker.base fail
because the VM has only 1 GiB of RAM.
Set the VM RAM to 2 GiB.

# How to use/testing done

Tested on ESXi (make sure you are the only one creating a VM there or set `--esx-first-static-ip` and `--esx-first-static-ip-private` to be higher and reduce `--esx-static-ips`):
```
$ wget https://alpha.release.flatcar-linux.net/amd64-usr/2492.0.0/flatcar_production_vmware_ova.ova
$ ./kola run -d --platform esx --esx-config-file esx.json --esx-ova-path flatcar_production_vmware_ova.ova docker.lib-coreos-dockerd-compat docker.base
```