### PR TITLE
kola/tests/docker: Test no-new-privileges security option

### DIFF
--- a/kola/tests/docker/docker.go
+++ b/kola/tests/docker/docker.go
@@ -242,8 +242,9 @@ func dockerBaseTests(c cluster.TestCluster) {
 }
 
 // using a simple container, exercise various docker options that set resource
-// limits. also acts as a regression test for
-// https://github.com/coreos/bugs/issues/1246.
+// limits and security options. also acts as a regression test for
+// https://github.com/coreos/bugs/issues/1246 and
+// https://github.com/flatcar-linux/Flatcar/issues/110
 func dockerResources(c cluster.TestCluster) {
 	m := c.Machines()[0]
 
@@ -280,6 +281,8 @@ func dockerResources(c cluster.TestCluster) {
 		dCmd("--memory=50m --oom-kill-disable=true"),
 		dCmd("--memory-swappiness=50"),
 		dCmd("--shm-size=1m"),
+		dCmd("--security-opt=label=disable --security-opt=no-new-privileges"),
+		dCmd("--security-opt=no-new-privileges"),
 	} {
 		// lol closures
 		cmd := dockerCmd


### PR DESCRIPTION
Extend the Docker option test with two --security-opt cases where
one currently broke in Alpha 2492.0.0. See
https://github.com/flatcar-linux/Flatcar/issues/110

# How to use

```
$ make
$ cd bin
$ wget https://alpha.release.flatcar-linux.net/amd64-usr/2492.0.0/flatcar_production_qemu_image.img.bz2
$ (l)bunzip2 flatcar_production_qemu_image.img.bz2
$ sudo ./kola run --qemu-image flatcar_production_qemu_image.img --qemu-skip-mangle docker.base
```

Result for Alpha as above (`WARNING` can be ignored):
```
=== RUN   docker.base
=== RUN   docker.base/docker-info
=== RUN   docker.base/resources
=== RUN   docker.base/networks-reliably
=== RUN   docker.base/user-no-caps
--- FAIL: docker.base (221.02s)
    --- PASS: docker.base/docker-info (0.57s)
    --- FAIL: docker.base/resources (49.74s)
            cluster.go:117: WARNING: Your kernel does not support Block I/O weight or the cgroup is not mounted. Weight discarded.
            cluster.go:117: standard_init_linux.go:211: exec user process caused "operation not permitted"
            docker.go:305: [0] failed to run "docker run --rm --security-opt=no-new-privileges sleep sleep 0.2": output: "" status: "Process exited with status 1"
    --- PASS: docker.base/networks-reliably (150.68s)
    --- PASS: docker.base/user-no-caps (0.92s)
FAIL, output in _kola_temp/qemu-2020-05-05-1224-231131
harness: test suite failed
```