### PR TITLE
sdk/repo/verify: Keep slashes in branch names

### DIFF
--- a/sdk/repo/verify.go
+++ b/sdk/repo/verify.go
@@ -149,12 +149,13 @@ func (r *repo) projectBranches(p Project) ([]string, error) {
 	for _, val := range strings.Split(string(out), ",") {
 		ref := strings.TrimSpace(val)
 
-		if strings.HasPrefix(ref, "HEAD") || strings.HasPrefix(ref, "tag:") {
-			// Skip "tag: tagname", "HEAD", and "HEAD -> branchname"
+		if strings.HasPrefix(ref, "HEAD") || strings.HasPrefix(ref, "tag:") || strings.Contains(ref, "refs/tags/") {
+			// Skip "tag: tagname", "HEAD", "HEAD -> branchname", and "m/refs/tags/tagname"
 			continue
 		}
 
-		parts := strings.Split(ref, "/")
+		// Take away the origin, for example, "github/branch/name" is "branch/name"
+		parts := strings.SplitN(ref, "/", 2)
 		branches = append(branches, parts[len(parts)-1])
 	}
 


### PR DESCRIPTION
The branch name was falsely assumed to contain no slashes.
Keep all slashes after the one that separates the origin.
Also filter away local tags which would break the rule that
all after the first slash is a branch name.

# How to use

# Testing done

