### PR TITLE
cork: Add SDK URL path parameter

### DIFF
--- a/cmd/cork/create.go
+++ b/cmd/cork/create.go
@@ -37,6 +37,7 @@ var (
 
 	// creation flags
 	creationFlags  *pflag.FlagSet
+	sdkUrlPath     string
 	sdkVersion     string
 	manifestURL    string
 	manifestName   string
@@ -104,6 +105,8 @@ func init() {
 		"use-host-dns", false, "Use the host's /etc/resolv.conf instead of 8.8.8.8 and 8.8.4.4")
 
 	creationFlags = pflag.NewFlagSet("creation", pflag.ExitOnError)
+	creationFlags.StringVar(&sdkUrlPath,
+		"sdk-url-path", "/flatcar-jenkins/sdk", "SDK URL path")
 	creationFlags.StringVar(&sdkVersion,
 		"sdk-version", "", "SDK version. Defaults to the SDK version in version.txt")
 	creationFlags.StringVar(&manifestURL,
@@ -225,7 +228,7 @@ func runCreate(cmd *cobra.Command, args []string) {
 
 func unpackChroot(replace bool) {
 	plog.Noticef("Downloading SDK version %s", sdkVersion)
-	if err := sdk.DownloadSDK(sdkVersion, verifyKeyFile); err != nil {
+	if err := sdk.DownloadSDK(sdkUrlPath, sdkVersion, verifyKeyFile); err != nil {
 		plog.Fatalf("Download failed: %v", err)
 	}
 

--- a/cmd/cork/download.go
+++ b/cmd/cork/download.go
@@ -27,11 +27,14 @@ var (
 		Long:  "Download the current SDK tarball to a local cache.",
 		Run:   runDownload,
 	}
+	downloadUrl           string
 	downloadVersion       string
 	downloadVerifyKeyFile string
 )
 
 func init() {
+	downloadCmd.Flags().StringVar(&downloadUrl,
+		"sdk-url-path", "/flatcar-jenkins/sdk", "SDK URL path")
 	downloadCmd.Flags().StringVar(&downloadVersion,
 		"sdk-version", "", "SDK version")
 	downloadCmd.Flags().StringVar(&downloadImageVerifyKeyFile,
@@ -49,7 +52,7 @@ func runDownload(cmd *cobra.Command, args []string) {
 	}
 
 	plog.Noticef("Downloading SDK version %s", downloadVersion)
-	if err := sdk.DownloadSDK(downloadVersion, downloadVerifyKeyFile); err != nil {
+	if err := sdk.DownloadSDK(downloadUrl, downloadVersion, downloadVerifyKeyFile); err != nil {
 		plog.Fatalf("Download failed: %v", err)
 	}
 }

--- a/sdk/download.go
+++ b/sdk/download.go
@@ -35,7 +35,6 @@ import (
 
 const (
 	urlHost = "storage.googleapis.com"
-	urlPath = "/flatcar-jenkins/sdk"
 )
 
 var plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "sdk")
@@ -45,7 +44,7 @@ func TarballName(version string) string {
 	return fmt.Sprintf("flatcar-sdk-%s-%s.tar.bz2", arch, version)
 }
 
-func TarballURL(version string) string {
+func TarballURL(urlPath, version string) string {
 	arch := system.PortageArch()
 	p := path.Join(urlPath, arch, version, TarballName(version))
 	u := url.URL{Scheme: "https", Host: urlHost, Path: p}
@@ -196,9 +195,9 @@ func DownloadSignedFile(file, url string, client *http.Client, verifyKeyFile str
 	return nil
 }
 
-func DownloadSDK(version, verifyKeyFile string) error {
+func DownloadSDK(urlPath, version, verifyKeyFile string) error {
 	tarFile := filepath.Join(RepoCache(), "sdks", TarballName(version))
-	tarURL := TarballURL(version)
+	tarURL := TarballURL(urlPath, version)
 	return DownloadSignedFile(tarFile, tarURL, nil, verifyKeyFile)
 }
 


### PR DESCRIPTION
The SDK path for the Google Cloud Storage URL was hardcoded to
point to the directory of SDK releases.
Add a parameter to allow to download a developer SDK build
(currently in /flatcar-jenkins/developer/sdk).

# How to use/test

```
$ mantle/bin/cork create --sdk-url-path '/flatcar-jenkins/developer/sdk' --sdk-version '2492.0.0+dev-flatcar-build-2492.0.0-local-418'
```