### PR TITLE
kola: force rkt to use docker API for quay

### DIFF
--- a/kola/tests/kubernetes/controllerInstall.go
+++ b/kola/tests/kubernetes/controllerInstall.go
@@ -238,7 +238,7 @@ Environment=ETCD_ENDPOINTS=${ETCD_ENDPOINTS}
 ExecStart=/usr/bin/rkt run --inherit-env --stage1-from-dir=stage1-fly.aci \
 --volume=modules,kind=host,source=/lib/modules,readOnly=false \
 --mount=volume=modules,target=/lib/modules \
---trust-keys-from-https quay.io/calico/node:v0.19.0
+--trust-keys-from-https --insecure-options=image docker://quay.io/calico/node:v0.19.0
 KillMode=mixed
 Restart=always
 TimeoutStartSec=0

--- a/kola/tests/kubernetes/workerInstall.go
+++ b/kola/tests/kubernetes/workerInstall.go
@@ -182,7 +182,7 @@ Environment=ETCD_ENDPOINTS=${ETCD_ENDPOINTS}
 ExecStart=/usr/bin/rkt run --inherit-env --stage1-from-dir=stage1-fly.aci \
 --volume=modules,kind=host,source=/lib/modules,readOnly=false \
 --mount=volume=modules,target=/lib/modules \
---trust-keys-from-https quay.io/calico/node:v0.19.0
+--trust-keys-from-https --insecure-options=image docker://quay.io/calico/node:v0.19.0
 KillMode=mixed
 Restart=always
 TimeoutStartSec=0


### PR DESCRIPTION
Ref: https://github.com/flatcar-linux/Flatcar/issues/121

Signed-off-by: Vincent Batts <vbatts@kinvolk.io>

# kola: force rkt to use docker API for quay

I don't want `--insecure-options=` to live on here, but rather test the places that rkt fetches from quay.io


# How to use

run the kola tests


# Testing done

Not done yet. I'm still learning this area.
