### PR TITLE
Add a gangue subcommand to clean up files in GCS

### DIFF
--- a/cmd/gangue/gangue.go
+++ b/cmd/gangue/gangue.go
@@ -19,14 +19,11 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"os"
-	"path"
 
 	"github.com/spf13/cobra"
 
 	"github.com/coreos/mantle/auth"
 	"github.com/coreos/mantle/cli"
-	"github.com/coreos/mantle/sdk"
 )
 
 var (
@@ -35,26 +32,13 @@ var (
 		Short: "Google Storage download and verification tool",
 	}
 
-	get = &cobra.Command{
-		Use:   "get [url] [path]",
-		Short: "download and verify a file from Google Storage",
-		Run:   run,
-	}
-
-	gpgKeyFile, jsonKeyFile      string
-	keepSig, serviceAuth, verify bool
+	jsonKeyFile string
+	serviceAuth bool
 )
 
 func init() {
-	bv := get.PersistentFlags().BoolVar
-	sv := get.PersistentFlags().StringVar
-
-	bv(&serviceAuth, "service-auth", false, "use non-interactive auth when running within GCE")
-	sv(&jsonKeyFile, "json-key", "", "use a service account's JSON key for authentication")
-	bv(&verify, "verify", true, "use GPG verification")
-	sv(&gpgKeyFile, "verify-key", "", "PGP public key file to verify signatures, or blank for the default key built into the program")
-	bv(&keepSig, "keep-sig", false, "keep the detached signature file on disk when successful")
-	root.AddCommand(get)
+	root.PersistentFlags().BoolVar(&serviceAuth, "service-auth", false, "use non-interactive auth when running within GCE")
+	root.PersistentFlags().StringVar(&jsonKeyFile, "json-key", "", "use a service account's JSON key for authentication")
 }
 
 func validateGSURL(rawURL string) error {
@@ -77,67 +61,17 @@ func validateGSURL(rawURL string) error {
 	return nil
 }
 
-func run(cmd *cobra.Command, args []string) {
-	var client *http.Client
-	var output, source string
-
-	if len(args) == 2 {
-		source = args[0]
-		output = args[1]
-	} else if len(args) == 1 {
-		source = args[0]
-		output = "."
-	} else {
-		fmt.Fprintf(os.Stderr, "Expected one or two arguments\n")
-		os.Exit(1)
-	}
-
-	// Perform some basic sanity checks on the options
-	err := validateGSURL(source)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
-	}
-	if output == "" {
-		output = "."
-	}
-
-	// If the output path exists and is a directory, keep the file name
-	if stat, err := os.Stat(output); err == nil && stat.IsDir() {
-		output = path.Join(output, path.Base(source))
-	}
-
-	// Authenticate with Google
+func getGoogleClient() (*http.Client, error) {
 	if serviceAuth {
-		client = auth.GoogleServiceClient()
+		return auth.GoogleServiceClient(), nil
 	} else if jsonKeyFile != "" {
-		b, err := ioutil.ReadFile(jsonKeyFile)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "%v\n", err)
-			os.Exit(1)
+		if b, err := ioutil.ReadFile(jsonKeyFile); err == nil {
+			return auth.GoogleClientFromJSONKey(b)
+		} else {
+			return nil, err
 		}
-		client, err = auth.GoogleClientFromJSONKey(b)
-	} else {
-		client, err = auth.GoogleClient()
 	}
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
-	}
-
-	// Download the file and verify it (unless disabled)
-	if verify {
-		err = sdk.UpdateSignedFile(output, source, client, gpgKeyFile)
-		if err == nil && !keepSig {
-			err = os.Remove(output + ".sig")
-		}
-	} else {
-		err = sdk.UpdateFile(output, source, client)
-	}
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
-	}
+	return auth.GoogleClient()
 }
 
 func main() {

--- a/cmd/gangue/get.go
+++ b/cmd/gangue/get.go
@@ -1,0 +1,97 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/spf13/cobra"
+
+	"github.com/coreos/mantle/sdk"
+)
+
+var (
+	get = &cobra.Command{
+		Use:   "get [url] [path]",
+		Short: "download and verify a file from Google Storage",
+		Run:   runGet,
+	}
+
+	gpgKeyFile      string
+	keepSig, verify bool
+)
+
+func init() {
+	bv := get.PersistentFlags().BoolVar
+	sv := get.PersistentFlags().StringVar
+
+	bv(&verify, "verify", true, "use GPG verification")
+	sv(&gpgKeyFile, "verify-key", "", "PGP public key file to verify signatures, or blank for the default key built into the program")
+	bv(&keepSig, "keep-sig", false, "keep the detached signature file on disk when successful")
+	root.AddCommand(get)
+}
+
+func runGet(cmd *cobra.Command, args []string) {
+	var output, source string
+
+	if len(args) == 2 {
+		source = args[0]
+		output = args[1]
+	} else if len(args) == 1 {
+		source = args[0]
+		output = "."
+	} else {
+		fmt.Fprintf(os.Stderr, "Expected one or two arguments\n")
+		os.Exit(1)
+	}
+
+	// Perform some basic sanity checks on the options
+	err := validateGSURL(source)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	if output == "" {
+		output = "."
+	}
+
+	// If the output path exists and is a directory, keep the file name
+	if stat, err := os.Stat(output); err == nil && stat.IsDir() {
+		output = path.Join(output, path.Base(source))
+	}
+
+	// Authenticate with Google
+	client, err := getGoogleClient()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+
+	// Download the file and verify it (unless disabled)
+	if verify {
+		err = sdk.UpdateSignedFile(output, source, client, gpgKeyFile)
+		if err == nil && !keepSig {
+			err = os.Remove(output + ".sig")
+		}
+	} else {
+		err = sdk.UpdateFile(output, source, client)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/gangue/prune.go
+++ b/cmd/gangue/prune.go
@@ -1,0 +1,105 @@
+// Copyright 2020 Kinvolk GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	prune = &cobra.Command{
+		Use:   "prune bucket-name path-to-analyze",
+		Short: "Delete old files from Google Cloud Storage",
+		Long:  "Recursively delete files in GCS bucket under path-to-analyze, if they are older than --days days.",
+		Run:   runPrune,
+	}
+
+	days      int
+	whitelist string
+)
+
+func init() {
+	prune.PersistentFlags().IntVar(&days, "days", 30, "Minimum age in days for files to get deleted")
+	prune.PersistentFlags().StringVar(&whitelist, "whitelist", "developer/", "Whitelist for path prefixes to consider")
+	root.AddCommand(prune)
+}
+
+func runPrune(cmd *cobra.Command, args []string) {
+
+	if len(args) != 2 {
+		fmt.Fprintf(os.Stderr, "bucket-name and path-to-analyze are required.\n")
+		os.Exit(1)
+	}
+
+	if jsonKeyFile == "" {
+		fmt.Fprintf(os.Stderr, "The --json-key filename is required.\n")
+		os.Exit(1)
+	}
+
+	bucketName := args[0]
+	pathPrefix := args[1]
+
+	if !strings.HasPrefix(pathPrefix, whitelist) {
+		fmt.Fprintf(os.Stderr, "The provided prefix (%s) isn't whitelisted (%s).\n", pathPrefix, whitelist)
+		os.Exit(1)
+	}
+
+	// Connect to GCS.
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx, option.WithCredentialsFile(jsonKeyFile))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Couldn't connect to GCS: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Open the bucket
+	bkt := client.Bucket(bucketName)
+
+	// Iterate over the contents of the prefix in the bucket.
+	cutOffDay := time.Now().AddDate(0, 0, -1*days)
+	query := &storage.Query{Prefix: pathPrefix}
+	it := bkt.Objects(ctx, query)
+	for {
+		attrs, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error iterating bucket %q: %v\n", bucketName, err)
+			os.Exit(1)
+		}
+		if strings.HasSuffix(attrs.Name, "/") {
+			fmt.Printf("Not checking %s\n", attrs.Name)
+		}
+		// Check the date of the object, delete it if it's older than the selected days
+		if attrs.Updated.Before(cutOffDay) {
+			fmt.Printf("%s is obsolete (%v) - Deleting\n", attrs.Name, attrs.Updated)
+			if err := bkt.Object(attrs.Name).Delete(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "Error deleting object %q: %v\n", attrs.Name, err)
+				os.Exit(1)
+			}
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/coreos/mantle
 go 1.12
 
 require (
+	cloud.google.com/go v0.34.0
 	github.com/Azure/azure-sdk-for-go v8.1.0-beta+incompatible
 	github.com/Azure/go-autorest v9.1.0+incompatible
 	github.com/Microsoft/azure-vhd-utils v0.0.0-20161127050200-43293b8d7646
@@ -32,6 +33,7 @@ require (
 	github.com/golang/protobuf v1.3.1
 	github.com/google/btree v1.0.0 // indirect
 	github.com/google/go-querystring v1.0.0 // indirect
+	github.com/googleapis/gax-go v1.0.3 // indirect
 	github.com/gophercloud/gophercloud v0.0.0-20180817041643-185230dfbd12
 	github.com/gorilla/websocket v1.4.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,10 @@ github.com/google/uuid v0.0.0-20170306145142-6a5e28554805/go.mod h1:TIyPZe4Mgqvf
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/googleapis/gax-go v1.0.3 h1:9dMLqhaibYONnDRcnHdUs9P8Mw64jLlZTYlDe3leBtQ=
+github.com/googleapis/gax-go v1.0.3/go.mod h1:QyXYajJFdARxGzjwUfbDFIse7Spkw81SJ4LrBJXtlQ8=
+github.com/googleapis/gax-go/v2 v2.0.2 h1:/rNgUniLy2vDXiK2xyJOcirGpC3G99dtK1NWx26WZ8Y=
+github.com/googleapis/gax-go/v2 v2.0.2/go.mod h1:LLvjysVCY1JZeum8Z6l8qUty8fiNwE08qbEPm1M08qg=
 github.com/gophercloud/gophercloud v0.0.0-20180817041643-185230dfbd12 h1:Pnd335IkPSdzn51MVDqWISOLvXo7vHUd4qoZ4L1LLIQ=
 github.com/gophercloud/gophercloud v0.0.0-20180817041643-185230dfbd12/go.mod h1:3WdhXV3rUYy9p6AUW8d94kr+HS62Y4VL9mBnFxsD8q4=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
@@ -191,12 +195,14 @@ github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9o
 github.com/vmware/vmw-ovflib v0.0.0-20170608004843-1f217b9dc714/go.mod h1:jiPk45kn7klhByRvUq5i2vo1RtHKBHj+iWGFpxbXuuI=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18 h1:MPPkRncZLN9Kh4MEFmbnK4h3BD7AUmskWv2+EeZJCCs=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
+go.opencensus.io v0.18.0 h1:Mk5rgZcggtbvtAun5aJzAtjKKN/t0R3jJPlWILlv938=
 go.opencensus.io v0.18.0/go.mod h1:vKdFvxhtzZ9onBp9VKHK8z/sRpBMnKAsufL7wlDrCOA=
 go4.org v0.0.0-20180809161055-417644f6feb5 h1:+hE86LblG4AyDgwMCLTE6FOlM9+qjHSYS+rKqxUVdsM=
 go4.org v0.0.0-20180809161055-417644f6feb5/go.mod h1:MkTOUMDaeVYJUOUsaDXIhWPZYa1yOyC1qaOBpL57BhE=
 golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67 h1:ng3VDlRp5/DHpSWl02R4rM9I+8M2rhmsuLwAMmkLQWE=
 golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/exp v0.0.0-20190221220918-438050ddec5e/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=


### PR DESCRIPTION
# Add a gangue subcommand to clean up files in GCS

By adding developer builds, we've started generating a lot of files in GCS that are actually ephemeral. This change adds a new `prune` subcommand to the gangue command (until now only `get` existed). This subcommand can be used to delete files under a specific path if they are older that some amount of days.

# How to use / Testing done

```
go build -o bin/gangue github.com/coreos/mantle/cmd/gangue
bin/gangue prune flatcar-jenkins developer/sdk \
    --json-key /path/to/creds/gce-service-account.json --days=15
```

This will delete all files older than 15 days under the `developer/sdk` path.  I've run this for sdk and for boards and verified that the files deleted were correct.

This change is part of the clean up needed for building PR branches (kinvolk/PROJECT-flatcar-linux#294)