### PR TITLE
kola/tests/docker: Skip no-new-privileges test for Docker 1.12

### DIFF
--- a/kola/tests/docker/docker.go
+++ b/kola/tests/docker/docker.go
@@ -260,7 +260,7 @@ func dockerResources(c cluster.TestCluster) {
 	wg := worker.NewWorkerGroup(ctx, 10)
 
 	// ref https://docs.docker.com/engine/reference/run/#runtime-constraints-on-resources
-	for _, dockerCmd := range []string{
+	cases := []string{
 		// must set memory when setting memory-swap
 		dCmd("--memory=50m --memory-swap=50m"),
 		dCmd("--memory-reservation=10m"),
@@ -282,8 +282,12 @@ func dockerResources(c cluster.TestCluster) {
 		dCmd("--memory-swappiness=50"),
 		dCmd("--shm-size=1m"),
 		dCmd("--security-opt=label=disable --security-opt=no-new-privileges"),
-		dCmd("--security-opt=no-new-privileges"),
-	} {
+	}
+	serverVersion := getDockerServerVersion(c, m)
+	if !strings.HasPrefix(serverVersion, "1.12") {
+		cases = append(cases, dCmd("--security-opt=no-new-privileges"))
+	}
+	for _, dockerCmd := range cases {
 		// lol closures
 		cmd := dockerCmd
 


### PR DESCRIPTION
Recently two Docker parameter test cases were added:
1. --security-opt=label=disable --security-opt=no-new-privileges
2. --security-opt=no-new-privileges
As the second case causes a Docker 1.12 runc panic in our current
setup, skip this test when Docker 1.12 is detected.


# How to use/test

```
$ make
$ make test
$ cd bin
$ ./kola run --board=amd64-usr --aws-ami=ami-0c7295725fccdee9b --aws-region=us-west-2 --aws-type=t3.small --aws-iam-profile=jenkins-test --platform=aws --channel=beta --torcx-manifest=torcx_manifest.json --aws-credentials-file ~/.aws/credentials-kola docker.torcx-manifest-pkgs
```
with this content for the file `torcx_manifest.json`:
```
{  "kind": "torcx-package-list-v0",  "value": {    "packages": [      {        "name": "docker",        "versions": [          {            "version": "1.12",            "hash": "sha512-9e96148af25d0b7badb33a70cc03ab7b9a2d6614b840685f605c62dfaae2b0ea2072af4b6c579e5829f1340772ec3b440368a3e0a7cdb34237087559e19566f9",            "casDigest": "9e96148af25d0b7badb33a70cc03ab7b9a2d6614b840685f605c62dfaae2b0ea2072af4b6c579e5829f1340772ec3b440368a3e0a7cdb34237087559e19566f9",            "sourcePackage": "~app-emulation/docker-1.12.6",            "locations": [              {                "path": "/usr/share/torcx/store/docker:1.12.torcx.tgz"              },              {                "url": "http://storage-download.googleapis.com/flatcar-jenkins/torcx/pkgs/amd64-usr/docker/9e96148af25d0b7badb33a70cc03ab7b9a2d6614b840685f605c62dfaae2b0ea2072af4b6c579e5829f1340772ec3b440368a3e0a7cdb34237087559e19566f9/docker:1.12.torcx.tgz"              }            ]          },          {            "version": "18.06",            "hash": "sha512-d3ebae43cfd9f3232a11e4aefb1050a1276d345c51f4cff93ed6cbe686364f54540b1c9300a2cb921c6bd28c5d59010b84ff1b6a8eabbf8972854f1f015afb6b",            "casDigest": "d3ebae43cfd9f3232a11e4aefb1050a1276d345c51f4cff93ed6cbe686364f54540b1c9300a2cb921c6bd28c5d59010b84ff1b6a8eabbf8972854f1f015afb6b",            "sourcePackage": "~app-emulation/docker-18.06.3",            "locations": [              {                "path": "/usr/share/torcx/store/docker:18.06.torcx.tgz"              },              {                "url": "http://storage-download.googleapis.com/flatcar-jenkins/torcx/pkgs/amd64-usr/docker/d3ebae43cfd9f3232a11e4aefb1050a1276d345c51f4cff93ed6cbe686364f54540b1c9300a2cb921c6bd28c5d59010b84ff1b6a8eabbf8972854f1f015afb6b/docker:18.06.torcx.tgz"              }            ]          },          {            "version": "17.03",            "hash": "sha512-5d9dbb7ce20ca519c45f7c0ddd1a08cdc80a5b6ee307e1e5fc365b10af554ea61492afe9c2163f80e05afc6c35164754866d062d1bb62b8cfd57489f948b05fc",            "casDigest": "5d9dbb7ce20ca519c45f7c0ddd1a08cdc80a5b6ee307e1e5fc365b10af554ea61492afe9c2163f80e05afc6c35164754866d062d1bb62b8cfd57489f948b05fc",            "sourcePackage": "~app-emulation/docker-17.03.2",            "locations": [              {                "url": "http://storage-download.googleapis.com/flatcar-jenkins/torcx/pkgs/amd64-usr/docker/5d9dbb7ce20ca519c45f7c0ddd1a08cdc80a5b6ee307e1e5fc365b10af554ea61492afe9c2163f80e05afc6c35164754866d062d1bb62b8cfd57489f948b05fc/docker:17.03.torcx.tgz"              }            ]          }        ],        "defaultVersion": "18.06"      }    ]  }}
```