### PR TITLE
kola/tests/kubernetes/kubelet_wrapper: Restart kubelet service

### DIFF
--- a/kola/tests/kubernetes/kubelet_wrapper.go
+++ b/kola/tests/kubernetes/kubelet_wrapper.go
@@ -36,7 +36,7 @@ systemd:
     enable: true
     contents: |-
       [Service]
-      Type=oneshot
+      Type=simple
       Environment=KUBELET_IMAGE_TAG=` + hyperkubeTag + `
       # var-log and resolv were at various times either in the kubelet-wrapper
       # docs or recommended to people
@@ -49,6 +49,8 @@ systemd:
       # that rkt runs the kubelet successfully, we haven't hit this regression,
       # so just printing the version is enough.
       ExecStart=/usr/lib/flatcar/kubelet-wrapper --version
+      Restart=on-failure
+      RestartSec=2
       [Install]
       WantedBy=multi-user.target
 `),


### PR DESCRIPTION
Encountering quay.io timeouts, the service failed and was detected
as failed service in the instance check of the
kubernetes.kubelet_wrapper.var-log-mount test.
Add a retry option to the kubelet service in case the errors can be
resolved quickly by running rkt again.


# How to use

```
/kola run -k -d --parallel=1 --basename=your-test --board=amd64-usr --channel=alpha --platform=azure '--azure-blob-url=https://flatcar.blob.core.windows.net/publish/flatcar-linux-2513.0.1-alpha.vhd?se=2099-12-31T23%3A59%3A59Z&sig=2T45Z2uti5b8lc%2BSC3NeeFd1NooUFlRcuGSy75Tokxc%3D&sp=rl&sr=b&sv=2015-02-21' --azure-location=northeurope --azure-profile ~/.azure/profile.json --azure-auth ~/.azure/credentials.json --tapfile=azure.tap kubernetes.kubelet_wrapper.var-log-mount
```

# Testing done

Ongoing…