### PR TITLE
azure: use one Resource Group for all tests

### DIFF
--- a/platform/machine/azure/cluster.go
+++ b/platform/machine/azure/cluster.go
@@ -83,10 +83,14 @@ func (ac *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 	return mach, nil
 }
 
+// Destroy deletes the Resource Group if it was created for this cluster, but it doesn't
+// delete the Resource Group if the cluster runs in the Flight's image Resource Group
 func (ac *cluster) Destroy() {
 	ac.BaseCluster.Destroy()
-	if e := ac.flight.api.TerminateResourceGroup(ac.ResourceGroup); e != nil {
-		plog.Errorf("Deleting resource group %v: %v", ac.ResourceGroup, e)
+	if ac.ResourceGroup != ac.flight.ImageResourceGroup {
+		if e := ac.flight.api.TerminateResourceGroup(ac.ResourceGroup); e != nil {
+			plog.Errorf("Deleting resource group %v: %v", ac.ResourceGroup, e)
+		}
 	}
 	ac.flight.DelCluster(ac)
 }

--- a/platform/machine/azure/machine.go
+++ b/platform/machine/azure/machine.go
@@ -93,7 +93,7 @@ func (am *machine) Destroy() {
 		plog.Warningf("Saving console for instance %v: %v", am.ID(), err)
 	}
 
-	if err := am.cluster.flight.api.TerminateInstance(am.ID(), am.ResourceGroup()); err != nil {
+	if err := am.cluster.flight.api.TerminateInstance(am.mach, am.ResourceGroup()); err != nil {
 		plog.Errorf("terminating instance: %v", err)
 	}
 


### PR DESCRIPTION
Each kola cluster created and destroyed its own Resource Group which
took 2-3 minutes.
Reuse the image Resource Group if it was created for the flight and
run all tests in it. To keep the amount of left over VM network objects
small, the IP addresses and NICs are deleted when an instance is
deleted - this could also be removed again if we see that deleting
these objects takes a lot of time.

# How to use/testing done

```
./kola run -d --parallel 1 -k --platform azure --azure-blob-url 'https://flatcar.blob.core.windows.net/publish/flatcar-linux-2513.1.0-alpha.vhd?se=2099-12-31T23%3A59%3A59Z&sig=q93Hf6UggelIS3VQ%2F9sIjoz0CeREpX93o9tgTnRBrqk%3D&sp=rl&sr=b&sv=2015-02-21' --azure-location YOURLOCATION --azure-profile azureProfile.json --azure-auth service-credentials.json
```
