### PR TITLE
ore/gcloud: Add Image Family when creating image

### DIFF
--- a/cmd/ore/gcloud/create-image.go
+++ b/cmd/ore/gcloud/create-image.go
@@ -116,6 +116,7 @@ func runCreateImage(cmd *cobra.Command, args []string) {
 	_, pending, err := api.CreateImage(&gcloud.ImageSpec{
 		Name:        imageNameGCE,
 		SourceImage: storageSrc,
+		Family:      createImageFamily,
 	}, createImageForce)
 	if err == nil {
 		err = pending.Wait()


### PR DESCRIPTION
# Add the image family when creating gcloud images

To make it easier to find the latest stable/beta/alpha image, we need to set the image family when adding images to gcloud.  This won't be relevant for images uploaded for Kola tests, but will be relevant for images uploaded to the public project

# How to use
```
bin/ore gcloud create-image --board=amd64-usr --family=flatcar-edge --source-root=gs://flatcar-jenkins/edge/boards --version=2466.99.0 --json-key /path/to/key.json
```

Then verify that the created image has a family field.

# Testing done

I've added the new images in the kinvolk-public project by running the above command (once per channel, for the corresponding version of each channel) and each image now has the right associated family.