### PR TITLE
cork: Set SDK version in the manifest version.txt

### DIFF
--- a/cmd/cork/create.go
+++ b/cmd/cork/create.go
@@ -224,6 +224,7 @@ func runCreate(cmd *cobra.Command, args []string) {
 
 	unpackChroot(allowReplace)
 	updateRepo()
+	sdk.SetManifestSDKVersion(sdkVersion)
 }
 
 func unpackChroot(replace bool) {
@@ -352,6 +353,7 @@ func runUpdate(cmd *cobra.Command, args []string) {
 	}
 
 	updateRepo()
+	sdk.SetManifestSDKVersion(sdkVersion)
 
 	if err := sdk.Enter(chrootName, false, false, updateCommand...); err != nil {
 		plog.Fatalf("update_chroot failed: %v", err)

--- a/sdk/version.go
+++ b/sdk/version.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -87,6 +88,23 @@ func OSRelease(root string) (ver Versions, err error) {
 	defer f.Close()
 
 	return parseVersions(f, "")
+}
+
+func SetManifestSDKVersion(version string) error {
+	versionPath := filepath.Join(RepoRoot(), ".repo", "manifests", "version.txt")
+	originalContent, err := ioutil.ReadFile(versionPath)
+	if err != nil {
+		return err
+	}
+
+	re := regexp.MustCompile(`FLATCAR_SDK_VERSION=.*`)
+	newContent := re.ReplaceAll(originalContent, []byte("FLATCAR_SDK_VERSION="+version))
+	err = ioutil.WriteFile(versionPath, newContent, 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func VersionsFromDir(dir string) (ver Versions, err error) {


### PR DESCRIPTION
The SDK version parameter for "cork create" and "cork update" was used
to download a specific SDK tar ball but the SDK version entry in
version.txt stayed on the original value of the manifest. This caused
"cork update" or a later update_chroot step to not find the right
binary packages.
Set the correct SDK version value in the version.txt file.


# How to use

```
mantle/bin/cork update --create --sdk-version VERSION
```

# Testing done

```
mantle/bin/cork update --create --sdk-version 2345.3.1
cat .repo/manifests/version.txt # verified the SDK version entry
cat chroot/etc/portage/make.conf # verified that update_chroot picked it up to download binary packages
```