### PR TITLE
kola/test/misc/users: Cover case of dereferenced login shell symlink

### DIFF
--- a/kola/tests/misc/users.go
+++ b/kola/tests/misc/users.go
@@ -56,6 +56,11 @@ func CheckUserShells(c cluster.TestCluster) {
 
 		username := userdata[0]
 		shell := userdata[6]
+		if shell == "/bin/sh" {
+			// gentent returns one entry for root with /bin/sh instead of /bin/bash
+			// but /bin/sh is anyway a symlink to /bin/bash
+			shell = "/bin/bash"
+		}
 		if shell != ValidUsers[username] && shell != "/sbin/nologin" {
 			badusers = append(badusers, user)
 		}


### PR DESCRIPTION
After the systemd 245 update `getent passwd` also reports an entry for
    root with a /bin/sh login shell. Since /bin/sh is a symlink to
    /bin/bash this is acceptable even though I didn't find out yet what
    caused this change.

# How to use/Testing done

```
wget https://storage.googleapis.com/flatcar-jenkins/developer/developer/boards/amd64-usr/2020.07.29+dev-flatcar-master-678/flatcar_production_qemu_image.img.bz2
lbunzip2 flatcar_production_qemu_image.img.bz2
sudo ./kola run --board=amd64-usr --channel=alpha --parallel=1 --platform=qemu --qemu-bios=bios-256k.bin --qemu-image flatcar_production_qemu_image.img cl.users.shells
rm flatcar_production_qemu_image.img
```