### PR TITLE
Improve QEMU debugging

### DIFF
--- a/kola/tests/misc/nfs.go
+++ b/kola/tests/misc/nfs.go
@@ -79,8 +79,6 @@ func testNFS(c cluster.TestCluster, nfsversion int, remotePath string) {
 		c.Fatalf("Cluster.NewMachine: %s", err)
 	}
 
-	defer m1.Destroy()
-
 	c.Log("NFS server booted.")
 
 	/* poke a file in /tmp */
@@ -125,8 +123,6 @@ systemd:
 	if err != nil {
 		c.Fatalf("Cluster.NewMachine: %s", err)
 	}
-
-	defer m2.Destroy()
 
 	c.Log("NFS client booted.")
 

--- a/kola/tests/misc/ntp.go
+++ b/kola/tests/misc/ntp.go
@@ -47,7 +47,6 @@ func NTP(c cluster.TestCluster) {
 	if err != nil {
 		c.Fatalf("Cluster.NewMachine: %s", err)
 	}
-	defer m.Destroy()
 
 	out := c.MustSSH(m, "networkctl status eth0")
 	if !bytes.Contains(out, []byte("NTP: 10.0.0.1")) {

--- a/kola/tests/systemd/journald.go
+++ b/kola/tests/systemd/journald.go
@@ -75,7 +75,6 @@ func journalRemote(c cluster.TestCluster) {
 	if err != nil {
 		c.Fatalf("Cluster.NewMachine: %s", err)
 	}
-	defer gateway.Destroy()
 
 	// log a unique message on gatewayd machine
 	msg := "supercalifragilisticexpialidocious"
@@ -86,7 +85,6 @@ func journalRemote(c cluster.TestCluster) {
 	if err != nil {
 		c.Fatalf("Cluster.NewMachine: %s", err)
 	}
-	defer collector.Destroy()
 
 	// collect logs from gatewayd machine
 	cmd := fmt.Sprintf("sudo systemd-run --unit systemd-journal-remote-client /usr/lib/systemd/systemd-journal-remote --url http://%s:19531", gateway.PrivateIP())

--- a/platform/local/dnsmasq.go
+++ b/platform/local/dnsmasq.go
@@ -187,6 +187,8 @@ func NewDnsmasq() (*Dnsmasq, error) {
 		return nil, err
 	}
 
+	plog.Debugf("dnsmasq PID (manual cleanup needed if --remove=false): %v", dm.dnsmasq.Pid())
+
 	var configTemplate *template.Template
 
 	if plog.LevelAt(capnslog.DEBUG) {

--- a/platform/machine/qemu/cluster.go
+++ b/platform/machine/qemu/cluster.go
@@ -118,7 +118,7 @@ func (qc *Cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 	fdnum += 1
 	extraFiles = append(extraFiles, tap.File)
 
-	plog.Debugf("NewMachine: %q", qmCmd)
+	plog.Debugf("NewMachine: %q, %q, %q", qmCmd, qm.IP(), qm.PrivateIP())
 
 	qm.qemu = qm.qc.NewCommand(qmCmd[0], qmCmd[1:]...)
 

--- a/platform/machine/qemu/cluster.go
+++ b/platform/machine/qemu/cluster.go
@@ -133,6 +133,8 @@ func (qc *Cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 		return nil, err
 	}
 
+	plog.Debugf("qemu PID (manual cleanup needed if --remove=false): %v", qm.qemu.Pid())
+
 	if err := platform.StartMachine(qm, qm.journal); err != nil {
 		qm.Destroy()
 		return nil, err

--- a/platform/machine/unprivqemu/cluster.go
+++ b/platform/machine/unprivqemu/cluster.go
@@ -118,6 +118,8 @@ func (qc *Cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 		return nil, err
 	}
 
+	plog.Debugf("qemu PID (manual cleanup needed if --remove=false): %v", qm.qemu.Pid())
+
 	pid := strconv.Itoa(qm.qemu.Pid())
 	err = util.Retry(6, 5*time.Second, func() error {
 		var err error

--- a/platform/machine/unprivqemu/cluster.go
+++ b/platform/machine/unprivqemu/cluster.go
@@ -131,6 +131,8 @@ func (qc *Cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 		return nil, err
 	}
 
+	plog.Debugf("Localhost port for SSH connections: %q", qm.ip)
+
 	if err := platform.StartMachine(qm, qm.journal); err != nil {
 		qm.Destroy()
 		return nil, err


### PR DESCRIPTION
- platform/machine/qemu: Log IP address in debug mode
- platform/machine/unprivqemu: Log localhost port for SSH connections
- Log PIDs of qemu machine processes for manual cleanup
- kola: Remove unnecessary deletion of test machines
    The cluster deletes all machines if needed. Deleting them inside the
    tests broke the --remove=false flag to keep machines for debugging.

# How to use/testing done

```
# --key PATH is needed because we run as root
sudo ./kola run -d --remove=false --key ~/.ssh/id_rsa.pub -k --board=amd64-usr --channel=alpha --parallel=1 --platform=qemu --qemu-bios=bios-256k.bin --qemu-image flatcar_production_qemu_image.img systemd.journal.remote 2> >(tee pidlog >&2)
# See test failing, enter with SSH:
ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ProxyCommand="sudo nsenter -n -t $(grep 'dnsmasq.*manual cleanup needed' pidlog | cut -d : -f 5) nc %h %p" -p 22 core@10.0.0.2
# Later kill the qemu and dnsmasq processes:
sudo kill $(grep 'manual cleanup needed' pidlog | cut -d : -f 5)
```
