### PR TITLE
Set mod=vendor when building with go install

### DIFF
--- a/test
+++ b/test
@@ -26,7 +26,7 @@ src=$(find . -name '*.go' -not -path "./vendor/*")
 
 echo "Building tests..."
 go test -mod=vendor -i "$@" $pkgs
-go install $pkgs
+go install -mod=vendor $pkgs
 
 echo "Running tests..."
 go test -mod=vendor -cover "$@" $pkgs


### PR DESCRIPTION
The CI does not have bzr installed and fails to fetch a module which
still uses this location.

# How to use

Build on a host system without `bzr`

# Testing done

None, maybe `replace launchpad.net/gocheck => gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b` is also needed
