### PR TITLE
platform/qemu: Use 4 virtual CPUs instead of 1

### DIFF
--- a/platform/qemu.go
+++ b/platform/qemu.go
@@ -271,7 +271,7 @@ func CreateQEMUCommand(board, uuid, biosImage, consolePath, confPath, diskImageP
 
 	qmCmd = append(qmCmd,
 		"-bios", biosImage,
-		"-smp", "1",
+		"-smp", "4",
 		"-uuid", uuid,
 		"-display", "none",
 		"-chardev", "file,id=log,path="+consolePath,


### PR DESCRIPTION
Using only a single core for the VMs limits the test execution speed.
Allocate 4 virtual CPUs which should be a good default.


# How to use

```
sudo ./kola run -d -k --qemu-image flatcar_production_qemu_image.img cl.basic
```

# Testing done

I entered the virtual machine as follows and checked the output of `lscpu`.
```
ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ProxyCommand="sudo nsenter -n -t $(ps -ef | grep '^dnsmasq.*dnsmasq --conf-file=-' | tail -n 1 | awk '{print $2}') nc %h %p" -p 22 core@10.0.0.2
```