### PR TITLE
Add LTS channel to plume and kola

### DIFF
--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -40,7 +40,7 @@ var (
 	kolaArchitectures  = []string{"amd64"}
 	kolaPlatforms      = []string{"aws", "azure", "do", "esx", "gce", "openstack", "packet", "qemu", "qemu-unpriv"}
 	kolaDistros        = []string{"cl", "fcos", "rhcos"}
-	kolaChannels       = []string{"alpha", "beta", "stable", "edge"}
+	kolaChannels       = []string{"alpha", "beta", "stable", "edge", "lts"}
 	kolaDefaultImages  = map[string]string{
 		"amd64-usr": sdk.BuildRoot() + "/images/amd64-usr/latest/flatcar_production_image.bin",
 		"arm64-usr": sdk.BuildRoot() + "/images/arm64-usr/latest/flatcar_production_image.bin",

--- a/cmd/plume/containerlinux.go
+++ b/cmd/plume/containerlinux.go
@@ -179,6 +179,28 @@ var (
 			),
 			AWS: newAWSSpec(),
 		},
+		"lts": channelSpec{
+			BaseURL:        "gs://flatcar-jenkins-private/lts/boards",
+			BasePrivateURL: "gs://flatcar-jenkins-private/lts/boards",
+			Boards:         []string{"amd64-usr"},
+			Destinations:   []storageSpec{},
+			GCE:            gceSpec{},
+			Azure: newAzureSpec(
+				azureEnvironments,
+				"publish",
+				"Flatcar LTS",
+				"",
+				"The LTS channel should be used by production clusters. Versions of Flatcar Container Linux are battle-tested within the Stable channel before being promoted.",
+			),
+			AzurePremium: newAzureSpec(
+				azureEnvironments,
+				"publish",
+				"Flatcar LTS",
+				"_pro",
+				"The LTS channel should be used by production clusters. Versions of Flatcar Container Linux are battle-tested within the Stable channel before being promoted.",
+			),
+			AWS: newAWSSpec(),
+		},
 		"developer": channelSpec{
 			BaseURL:        "gs://flatcar-jenkins/developer/developer/boards",
 			BasePrivateURL: "gs://flatcar-jenkins-private/developer/developer/boards",

--- a/cmd/plume/release.go
+++ b/cmd/plume/release.go
@@ -446,6 +446,10 @@ func doAWS(ctx context.Context, client *http.Client, src *storage.Bucket, spec *
 		plog.Notice("AWS image creation disabled.")
 		return
 	}
+	if specChannel == "lts" {
+		plog.Notice("Not publishing LTS AMIs.")
+		return
+	}
 
 	awsImageMetadata, err := getSpecAWSImageMetadata(spec)
 	if err != nil {


### PR DESCRIPTION
This makes kola accept the `lts` channel parameter for test filtering and also registers the LTS channel to plume for Azure/AWS but doesn't make AMIs public.

# How to use

Use with Jenkins

# Testing done

None