### PR TITLE
Retry mounting the loop device in QEMU and improve error messages

### DIFF
--- a/kola/harness.go
+++ b/kola/harness.go
@@ -356,7 +356,7 @@ func RunTests(patterns []string, channel, pltfrm, outputDir string, sshKeys *[]a
 
 	flight, err := NewFlight(pltfrm)
 	if err != nil {
-		plog.Fatalf("Flight failed: %v", err)
+		plog.Fatalf("creating flight for RunTests failed: %v", err)
 	}
 	(*flight.GetBaseFlight()).AdditionalSshKeys = sshKeys
 	if remove {

--- a/platform/local/flight.go
+++ b/platform/local/flight.go
@@ -46,14 +46,14 @@ type LocalFlight struct {
 func NewLocalFlight(opts *platform.Options, platformName platform.Name) (*LocalFlight, error) {
 	nshandle, err := ns.Create()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("creating new ns handle failed: %v", err)
 	}
 
 	nsdialer := network.NewNsDialer(nshandle)
 	bf, err := platform.NewBaseFlightWithDialer(opts, platformName, "", nsdialer)
 	if err != nil {
 		nshandle.Close()
-		return nil, err
+		return nil, fmt.Errorf("creating new base flight failed: %v", err)
 	}
 
 	lf := &LocalFlight{
@@ -68,28 +68,28 @@ func NewLocalFlight(opts *platform.Options, platformName platform.Name) (*LocalF
 	nsExit, err := ns.Enter(lf.nshandle)
 	if err != nil {
 		lf.Destroy()
-		return nil, err
+		return nil, fmt.Errorf("entering new ns failed: %v", err)
 	}
 	defer nsExit()
 
 	lf.Dnsmasq, err = NewDnsmasq()
 	if err != nil {
 		lf.Destroy()
-		return nil, err
+		return nil, fmt.Errorf("creating new dnsmasq failed: %v", err)
 	}
 	lf.AddDestructor(lf.Dnsmasq)
 
 	lf.SimpleEtcd, err = NewSimpleEtcd()
 	if err != nil {
 		lf.Destroy()
-		return nil, err
+		return nil, fmt.Errorf("creating new simple etcd failed: %v", err)
 	}
 	lf.AddDestructor(lf.SimpleEtcd)
 
 	lf.NTPServer, err = ntp.NewServer(":123")
 	if err != nil {
 		lf.Destroy()
-		return nil, err
+		return nil, fmt.Errorf("creating new ntp server failed: %v", err)
 	}
 	lf.AddCloser(lf.NTPServer)
 	go lf.NTPServer.Serve()

--- a/platform/machine/qemu/flight.go
+++ b/platform/machine/qemu/flight.go
@@ -61,7 +61,7 @@ var (
 func NewFlight(opts *Options) (platform.Flight, error) {
 	lf, err := local.NewLocalFlight(opts.Options, Platform)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("creating local flight failed: %v", err)
 	}
 
 	qf := &flight{
@@ -78,7 +78,7 @@ func NewFlight(opts *Options) (platform.Flight, error) {
 		info, err := util.GetImageInfo(opts.DiskImage)
 		if err != nil {
 			qf.Destroy()
-			return nil, err
+			return nil, fmt.Errorf("getting image info failed: %v", err)
 		}
 		if info.Format != "raw" {
 			// platform.MakeCLDiskTemplate() needs to be able to mount
@@ -92,7 +92,7 @@ func NewFlight(opts *Options) (platform.Flight, error) {
 		qf.diskImageFile, err = platform.MakeCLDiskTemplate(opts.DiskImage)
 		if err != nil {
 			qf.Destroy()
-			return nil, err
+			return nil, fmt.Errorf("creating disk image file failed: %v", err)
 		}
 		// The template file has already been deleted, ensuring that
 		// it will be cleaned up on exit.  Use a path to it that


### PR DESCRIPTION
# Retry mounting the loop device in QEMU and improve error messages

I've been chasing an error that has turned up in our Jenkins workers in the past few days where sometimes QEMU would fail the mount operation for the OEM partition of the loop device.  To understand the problem better, I've added a bunch of additional error messages here and there.

Eventually, I found that the problem was caused by the loop devices getting created twice, with a brief pause in between where they didn't exist.  This turns up in dmesg like this:

```
[399319.680160]  loop1: p1 p2 p3 p4 p6 p7 p9
[399319.705589]  loop1: p1 p2 p3 p4 p6 p7 p9
```

With some additional debugging info (not included in this PR), I could see this:

```
2020-09-24T13:06:46Z platform: oemdev file stat: &{loop1p6 0 67109248 {447130408 63736549606 0x388a680} {5 85487090 1 24960 0 0 0 66309 0 4096 0 {1600952806 447130408} {1600952806 447130408} {1600952806 447130408} [0 0 0]}}, <nil>
2020-09-24T13:06:46Z platform: oemdev file stat: <nil>, stat /dev/loop1p6: no such file or directory
2020-09-24T13:06:46Z etcdserver: skipped leadership transfer for single member cluster
2020-09-24T13:06:46Z kola: creating flight for RunTests failed: creating disk image file failed: mounting OEM partition /dev/loop1p6 on /tmp/kola-qemu-698081288: exit status 32: mount: /tmp/kola-qemu-698081288: special device /dev/loop1p6 does not exist.
```

The first line was inside the retry stat loop, showing that the device existed. The second line was after the mount call had failed, showing that the device didn't exist anymore.

It's unclear why this is happening. It might be related to kernel 5.8. Or it might be related to the new qemu. Whatever the case, we don't want tests randomly failing because of this, so I've added a retry block to the mount operation.

# How to use / Testing done

Build kola and run it on one of our Jenkins workers running Alpha. Verify that it works fine even when the loop devices appear twice in `dmesg`.

# Notes

This runs with the kola binary inside the SDK, we'll need to update the pointer in coreos-overlay for it to be picked up.