### PR TITLE
kola: Resolve relative paths to the same directory

### DIFF
--- a/kola/tests/coretest/core.go
+++ b/kola/tests/coretest/core.go
@@ -271,6 +271,8 @@ func TestSymlinkFlatcar() error {
 		if err != nil {
 			return fmt.Errorf("unable to resolve symlink %s.", f)
 		}
+		// Works for us but in general the canonical path should be resolved.
+		resolved = strings.TrimPrefix(resolved, "./")
 		if resolved != filepath.Base(flatcarPath) {
 			return fmt.Errorf("resolved path %s does not point to %s", resolved, filepath.Base(flatcarPath))
 		}


### PR DESCRIPTION
When a symlink is relative and not absolute and it's having a ./ prefix
the test was reporting an error because it expected to get the plain
filename of a relative path.
Trim any ./ prefix to relax the constraints.



# How to use

Run `cl.basic` tests with the unreleased image.

# Testing done

None