### PR TITLE
platform/machine/packet: No need for prev console log to exist to retry

### DIFF
--- a/platform/machine/packet/cluster.go
+++ b/platform/machine/packet/cluster.go
@@ -53,10 +53,10 @@ func (pc *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 	// maximal number of retries is reached or to print it at the beginning of the loop.
 	for retry := 0; retry <= 2; retry++ {
 		if err != nil {
-			plog.Infof("Retrying to provision a machine after error: %q", err)
+			plog.Warningf("Retrying to provision a machine after error: %q", err)
 			if pc.sshKeyID != "" {
 				err = os.Remove(consolePath)
-				if err != nil {
+				if err != nil && !os.IsNotExist(err) {
 					return nil, err
 				}
 			}


### PR DESCRIPTION
The console log file could have been deleted when destroying the
unsuccessful machine, thus don't error out when the file can't be
deleted again. Also don't hide the previous error behind the INFO log
level which is not the default.

# How to use

Run kola tests on Packet.

# Testing done

None