### PR TITLE
platform/qemu: Back HW random device with /dev/urandom

### DIFF
--- a/platform/qemu.go
+++ b/platform/qemu.go
@@ -281,6 +281,8 @@ func CreateQEMUCommand(board, uuid, biosImage, consolePath, confPath, diskImageP
 		"-display", "none",
 		"-chardev", "file,id=log,path="+consolePath,
 		"-serial", "chardev:log",
+		"-object", "rng-random,filename=/dev/urandom,id=rng0",
+		"-device", "virtio-rng-pci,rng=rng0",
 	)
 
 	if isIgnition {


### PR DESCRIPTION
As the flatcar_production_qemu*.sh scripts already do, use the fast
/dev/urandom device from the host as HW random source inside the guest.

# How to use/testing done

```
sudo ./kola run -d --platform qemu --qemu-image flatcar_production_image.bin cl.basic
sudo ./kola run -d --platform qemu --board arm64-usr --qemu-bios flatcar_production_qemu_uefi_efi_code.fd --qemu-image flatcar_production_image.bin cl.basic
```
