### PR TITLE
Packet: Set OEM ID for PXE boot network setup

### DIFF
--- a/platform/api/packet/api.go
+++ b/platform/api/packet/api.go
@@ -465,7 +465,7 @@ func (a *API) uploadObject(hostname, contentType string, data []byte) (string, s
 func (a *API) ipxeScript(userdataURL string) string {
 	return fmt.Sprintf(`#!ipxe
 set base-url %s
-kernel ${base-url}/flatcar_production_pxe.vmlinuz initrd=flatcar_production_pxe_image.cpio.gz flatcar.first_boot=1 ignition.config.url=%s console=%s
+kernel ${base-url}/flatcar_production_pxe.vmlinuz initrd=flatcar_production_pxe_image.cpio.gz flatcar.first_boot=1 flatcar.oem.id=packet ignition.config.url=%s console=%s
 initrd ${base-url}/flatcar_production_pxe_image.cpio.gz
 boot`, strings.TrimRight(a.opts.InstallerImageBaseURL, "/"), userdataURL, linuxConsole[a.opts.Board])
 }


### PR DESCRIPTION
Without any OEM information the default DHCP setup for one of the
interfaces works ok and is required to work inside the initramfs
but later after the initramfs the network setup provided by the
metadata server should be used. This is what is currently used in the
real PXE installation processes and should be covered by our CI. It is
also needed as soon as there is a change that assumes the network setup
according to the metadata server is done after the initramfs.

# How to use

Run kola tests

# Testing done

None