### PR TITLE
kola: fix S3 URLs for ignition tests

### DIFF
--- a/kola/tests/ignition/resource.go
+++ b/kola/tests/ignition/resource.go
@@ -127,7 +127,7 @@ func init() {
 			      "filesystem": "root",
 			      "path": "/var/resource/http",
 			      "contents": {
-				  "source": "http://s3-us-west-2.amazonaws.com/kola-fixtures/resources/anonymous"
+				  "source": "http://kola-fixtures.s3.eu-central-1.amazonaws.com/resources/anonymous"
 			      },
 			      "mode": 420
 			  },
@@ -135,7 +135,7 @@ func init() {
 			      "filesystem": "root",
 			      "path": "/var/resource/https",
 			      "contents": {
-				  "source": "https://s3-us-west-2.amazonaws.com/kola-fixtures/resources/anonymous"
+				  "source": "https://kola-fixtures.s3.eu-central-1.amazonaws.com/resources/anonymous"
 			      },
 			      "mode": 420
 			  },
@@ -159,14 +159,14 @@ func init() {
 			  {
 			      "path": "/var/resource/http",
 			      "contents": {
-				  "source": "http://s3-us-west-2.amazonaws.com/kola-fixtures/resources/anonymous"
+				  "source": "http://kola-fixtures.s3.eu-central-1.amazonaws.com/resources/anonymous"
 			      },
 			      "mode": 420
 			  },
 			  {
 			      "path": "/var/resource/https",
 			      "contents": {
-				  "source": "https://s3-us-west-2.amazonaws.com/kola-fixtures/resources/anonymous"
+				  "source": "https://kola-fixtures.s3.eu-central-1.amazonaws.com/resources/anonymous"
 			      },
 			      "mode": 420
 			  },
@@ -254,7 +254,7 @@ func init() {
 			      "filesystem": "root",
 			      "path": "/var/resource/original",
 			      "contents": {
-				  "source": "http://s3-us-west-2.amazonaws.com/kola-fixtures/resources/versioned?versionId=null"
+				  "source": "http://kola-fixtures.s3.eu-central-1.amazonaws.com/resources/versioned?versionId=null"
 			      },
 			      "mode": 420
 			  },
@@ -262,7 +262,7 @@ func init() {
 			      "filesystem": "root",
 			      "path": "/var/resource/latest",
 			      "contents": {
-				  "source": "http://s3-us-west-2.amazonaws.com/kola-fixtures/resources/versioned?versionId=RDWqxfnlcJOSDf1.5jy6ZP.oK9Bt7_Id"
+				  "source": "http://kola-fixtures.s3.eu-central-1.amazonaws.com/resources/versioned?versionId=kihPXL28M3YwRrU0Dbjie2Q.xFfmv8hi"
 			      },
 			      "mode": 420
 			  }
@@ -278,14 +278,14 @@ func init() {
 			  {
 			      "path": "/var/resource/original",
 			      "contents": {
-				  "source": "http://s3-us-west-2.amazonaws.com/kola-fixtures/resources/versioned?versionId=null"
+				  "source": "http://kola-fixtures.s3.eu-central-1.amazonaws.com/resources/versioned?versionId=null"
 			      },
 			      "mode": 420
 			  },
 			  {
 			      "path": "/var/resource/latest",
 			      "contents": {
-				  "source": "http://s3-us-west-2.amazonaws.com/kola-fixtures/resources/versioned?versionId=RDWqxfnlcJOSDf1.5jy6ZP.oK9Bt7_Id"
+				  "source": "http://kola-fixtures.s3.eu-central-1.amazonaws.com/resources/versioned?versionId=kihPXL28M3YwRrU0Dbjie2Q.xFfmv8hi"
 			      },
 			      "mode": 420
 			  }
@@ -353,14 +353,14 @@ func resourceS3(c cluster.TestCluster) {
 
 	// verify that the objects are inaccessible anonymously
 	for _, objectName := range []string{"authenticated", "authenticated.ign"} {
-		_, _, err := m.SSH("curl -sf https://s3-us-west-2.amazonaws.com/kola-fixtures/resources/" + objectName)
+		_, _, err := m.SSH("curl -sf https://kola-fixtures.s3.eu-central-1.amazonaws.com/resources/" + objectName)
 		if err == nil {
 			c.Fatal("anonymously fetching authenticated resource should have failed, but did not")
 		}
 	}
 
 	// ...but that the anonymous object is accessible
-	c.MustSSH(m, "curl -sf https://s3-us-west-2.amazonaws.com/kola-fixtures/resources/anonymous")
+	c.MustSSH(m, "curl -sf https://kola-fixtures.s3.eu-central-1.amazonaws.com/resources/anonymous")
 }
 
 func resourceS3Versioned(c cluster.TestCluster) {


### PR DESCRIPTION
Since the original S3 bucket `kola-fixtures` was renamed to `rh-kola-fixtures`, we are not able to use the bucket any more.
So we have set up a Flatcar-specific bucket for kola tests. `kola-fixtures` in the `eu-central-1` region.

Those can be accessed via
https://kola-fixtures.s3.eu-central-1.amazonaws.com/resources/...

## Testing done

TBD