### PR TITLE
kola/misc/raid: change CLC to raw ignition config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed `amd64` checksums for Kubernetes `v1.21.0` tests ([#226](https://github.com/kinvolk/mantle/pull/226))
 - Used `clc` to set `enable_v2` option ([#227](https://github.com/kinvolk/mantle/pull/227))
 - Bumped `CiliumCLI` version to pull `Cilium-1.10.4` ([#240](https://github.com/kinvolk/mantle/pull/230))
+- Used `ignition` instead of `clc` to provision instance in `raid` test ([#234](https://github.com/flatcar-linux/mantle/pull/234))
 
 ### Removed
 - Duplicated `etcd-member` in the `kubeadm.*` config ([#232](https://github.com/kinvolk/mantle/pull/232))

--- a/kola/tests/misc/raid.go
+++ b/kola/tests/misc/raid.go
@@ -26,37 +26,68 @@ import (
 )
 
 var (
-	raidRootUserData = conf.ContainerLinuxConfig(`storage:
-  disks:
-    - device: "/dev/disk/by-id/virtio-secondary"
-      wipe_table: true
-      partitions:
-       - label: root1
-         number: 1
-         size: 256MiB
-         type_guid: be9067b9-ea49-4f15-b4f6-f36f8c9e1818
-       - label: root2
-         number: 2
-         size: 256MiB
-         type_guid: be9067b9-ea49-4f15-b4f6-f36f8c9e1818
-  raid:
-    - name: "rootarray"
-      level: "raid1"
-      devices:
-        - "/dev/disk/by-partlabel/root1"
-        - "/dev/disk/by-partlabel/root2"
-  filesystems:
-    - name: "ROOT"
-      mount:
-        device: "/dev/md/rootarray"
-        format: "ext4"
-        label: ROOT
-    - name: "NOT_ROOT"
-      mount:
-        device: "/dev/disk/by-id/virtio-primary-disk-part9"
-        format: "ext4"
-        label: wasteland
-        wipe_filesystem: true`)
+	raidRootUserData = conf.Ignition(`{
+  "ignition": {
+    "config": {},
+    "security": {
+      "tls": {}
+    },
+    "timeouts": {},
+    "version": "2.3.0"
+  },
+  "networkd": {},
+  "storage": {
+    "disks": [
+      {
+        "device": "/dev/disk/by-id/virtio-secondary",
+        "partitions": [
+          {
+            "label": "root1",
+            "number": 1,
+            "sizeMiB": 256,
+            "typeGuid": "be9067b9-ea49-4f15-b4f6-f36f8c9e1818"
+          },
+          {
+            "label": "root2",
+            "number": 2,
+            "sizeMiB": 256,
+            "typeGuid": "be9067b9-ea49-4f15-b4f6-f36f8c9e1818"
+          }
+        ],
+        "wipeTable": true
+      }
+    ],
+    "filesystems": [
+      {
+        "mount": {
+          "device": "/dev/md/rootarray",
+          "format": "ext4",
+          "label": "ROOT"
+        },
+        "name": "ROOT"
+      },
+      {
+        "mount": {
+          "device": "/dev/disk/by-id/virtio-primary-disk-part9",
+          "format": "ext4",
+          "label": "wasteland",
+          "wipeFilesystem": true
+        },
+        "name": "NOT_ROOT"
+      }
+    ],
+    "raid": [
+      {
+        "devices": [
+          "/dev/disk/by-partlabel/root1",
+          "/dev/disk/by-partlabel/root2"
+        ],
+        "level": "raid1",
+        "name": "rootarray"
+      }
+    ]
+  }
+}`)
 )
 
 func init() {


### PR DESCRIPTION
`size` has been deprecated to `sizeMiB` from `ignition-2.3` and this
parameter is not translatable. See the discussion in here: https://github.com/coreos/ign-converter/pull/29

Since CLC is converted to `ignition-2.2` we can't rely on this to pass
the config so we directly use raw ignition 2.3.0 to provision the
instance.

This test only runs on `qemu` so there is no side effect to pass from
`clc` to `ignition`.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

## Testing done

Tested against:
* alpha-2983.0.0
* image with ignition/v3 from: https://github.com/flatcar-linux/coreos-overlay/pull/1249
