### PR TITLE
kola/test/oem: add ignition OEM test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - `kubeadm` proper support for ARM64 ([#217](https://github.com/kinvolk/mantle/pull/217))
 - docker logs forwarding to `journald` for `kubeadm.*` tests ([#228](https://github.com/kinvolk/mantle/pull/228))
+- `OEM` ignitions tests ([#235](https://github.com/flatcar-linux/mantle/pull/235))
 
 ### Changed
 - Enabled SELinux for ARM64 ([#222](https://github.com/kinvolk/mantle/pull/222/))

--- a/kola/tests/ignition/oem.go
+++ b/kola/tests/ignition/oem.go
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ignition
+
+import (
+	"github.com/coreos/go-semver/semver"
+	"github.com/coreos/mantle/kola/cluster"
+	"github.com/coreos/mantle/kola/register"
+	"github.com/coreos/mantle/platform/conf"
+)
+
+func init() {
+	register.Register(&register.Test{
+		Name:        "cl.ignition.oem.regular",
+		Run:         reusePartition,
+		ClusterSize: 1,
+		Distros:     []string{"cl"},
+		MinVersion:  semver.Version{Major: 2983},
+		UserData: conf.ContainerLinuxConfig(`storage:
+  filesystems:
+     - name: oem
+       mount:
+         device: "/dev/disk/by-label/OEM"
+         format: "btrfs"
+  files:
+    - path: /grub.cfg
+      filesystem: oem
+      mode: 0644
+      contents:
+        inline: |
+          set linux_append="flatcar.autologin"`),
+	})
+	register.Register(&register.Test{
+		Name:        "cl.ignition.oem.reuse",
+		Run:         reusePartition,
+		ClusterSize: 1,
+		Distros:     []string{"cl"},
+		MinVersion:  semver.Version{Major: 2983},
+		UserData: conf.ContainerLinuxConfig(`storage:
+  filesystems:
+     - name: oem
+       mount:
+         device: "/dev/disk/by-label/OEM"
+         format: "ext4"
+  files:
+    - path: /grub.cfg
+      filesystem: oem
+      mode: 0644
+      contents:
+        inline: |
+          set linux_append="flatcar.autologin"`),
+	})
+	register.Register(&register.Test{
+		Name:        "cl.ignition.oem.wipe",
+		Run:         wipeOEM,
+		MinVersion:  semver.Version{Major: 2983},
+		ClusterSize: 1,
+		UserData: conf.ContainerLinuxConfig(`storage:
+  filesystems:
+     - name: oem
+       mount:
+         device: "/dev/disk/by-label/OEM"
+         format: "ext4"
+         wipe_filesystem: true
+         label: "OEM"
+  files:
+    - path: /grub.cfg
+      filesystem: oem
+      mode: 0644
+      contents:
+        inline: |
+          set linux_append="flatcar.autologin"`),
+	})
+}
+
+// reusePartition asserts that even if the config uses a different fs format, we keep using `btrfs`.
+func reusePartition(c cluster.TestCluster) {
+	out := c.MustSSH(c.Machines()[0], `lsblk --output FSTYPE,LABEL,MOUNTPOINT --json | jq -r '.blockdevices | .[] | select(.label=="OEM") | .fstype'`)
+
+	if string(out) != "btrfs" {
+		c.Fatalf("should get btrfs, got: %s", string(out))
+	}
+}
+
+// wipeOEM asserts that if the config uses a different fs format with a wipe of the fs we effectively wipe the fs.
+func wipeOEM(c cluster.TestCluster) {
+	out := c.MustSSH(c.Machines()[0], `lsblk --output FSTYPE,LABEL,MOUNTPOINT --json | jq -r '.blockdevices | .[] | select(.label=="OEM") | .fstype'`)
+
+	if string(out) != "ext4" {
+		c.Fatalf("should get ext4, got: %s", string(out))
+	}
+}


### PR DESCRIPTION
Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>


In this PR, we try to test the usage of OEM - which is too required to run tests for the "new" ignition(v2/v3)

Closes: https://github.com/flatcar-linux/Flatcar/issues/486

Three tests:
* try to reuse the partition using a `btrfs` format
* try to reuse the parition using `ext4` format
* wipe the partition by using `wipeFilesystem`

## How to use

```
$ ./bin/kola list | grep oem
cl.ignition.oem.regular			[all]								[all]		[cl]		[all]		[all]
cl.ignition.oem.reuse			[all]								[all]		[cl]		[all]		[all]
cl.ignition.oem.wipe			[all]								[all]		[all]		[all]		[all]
```

## Testing done

Only on `qemu`.
