### PR TITLE
kola/ignition/oem: exclude `esx` and `azure` from platforms

### DIFF
--- a/kola/tests/ignition/oem.go
+++ b/kola/tests/ignition/oem.go
@@ -67,6 +67,10 @@ func init() {
 		Run:         wipeOEM,
 		MinVersion:  semver.Version{Major: 2983},
 		ClusterSize: 1,
+		// `wiping` the OEM file system does not allow the instance to boot on platforms
+		// different from QEMU.
+		// More details: https://github.com/flatcar-linux/Flatcar/issues/514.
+		Platforms: []string{"qemu", "qemu-unpriv"},
 		UserData: conf.ContainerLinuxConfig(`storage:
   filesystems:
      - name: oem


### PR DESCRIPTION
`wiping` the OEM file system does not allow the instance to boot. Let's
exclude the platform while we proceed to further investigations.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

Related-to: https://github.com/flatcar-linux/Flatcar/issues/514
