### PR TITLE
sdk: Updated SDK URL

### DIFF
--- a/cmd/cork/create.go
+++ b/cmd/cork/create.go
@@ -122,7 +122,7 @@ func init() {
 
 	creationFlags = pflag.NewFlagSet("creation", pflag.ExitOnError)
 	creationFlags.StringVar(&sdkUrlPath,
-		"sdk-url-path", "/flatcar-jenkins/sdk", "SDK URL path")
+		"sdk-url-path", "/sdk", "SDK URL path")
 	creationFlags.StringVar(&sdkVersion,
 		"sdk-version", "", "SDK version. Defaults to the SDK version in version.txt")
 	creationFlags.StringVar(&manifestURL,

--- a/sdk/download.go
+++ b/sdk/download.go
@@ -34,7 +34,7 @@ import (
 )
 
 const (
-	urlHost = "storage.googleapis.com"
+	urlHost = "mirror.release.flatcar-linux.net"
 )
 
 var plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "sdk")


### PR DESCRIPTION
# Updated SDK URL

The URL to the SDK has been updated, since this was moved from Google Cloud to the Flatcar repo server.

## How to use

1. Build the cork SDK using `./build`
2. Create a new chroot development environment using `cork create --verbose --manifest-branch flatcar-alpha-2983.0.0`

## Testing done

I have run the command `cork create --verbose --manifest-branch flatcar-alpha-2983.0.0` and got the correct output. The files are being downloaded, verified and unpacked. The output is too long and irrelevant to post here.
