### PR TITLE
`cork`: add `--json-key` to `create` and `download`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `kubeadm` proper support for ARM64 ([#217](https://github.com/kinvolk/mantle/pull/217))
 - docker logs forwarding to `journald` for `kubeadm.*` tests ([#228](https://github.com/kinvolk/mantle/pull/228))
 - `OEM` ignitions tests ([#235](https://github.com/flatcar-linux/mantle/pull/235))
+- `--json-key` to `cork/create` and `cork/download` subcommands ([#239](https://github.com/flatcar-linux/mantle/pull/239))
 
 ### Changed
 - Enabled SELinux for ARM64 ([#222](https://github.com/kinvolk/mantle/pull/222/))

--- a/cmd/cork/create.go
+++ b/cmd/cork/create.go
@@ -135,6 +135,8 @@ func init() {
 		"repo-branch", repoUpstreamBranch, "Branch name to be used from the upstream git repo of repo tool")
 	creationFlags.BoolVar(&repoVerify,
 		"verify", false, "Check repo tree and release manifest match")
+	creationFlags.StringVar(&downloadImageJSONKeyFile,
+		"json-key", "", "Google service account key for use with private buckets")
 	creationFlags.StringVar(&verifyKeyFile,
 		"verify-key", "", "PGP public key to be used in verifing download signatures.  Defaults to CoreOS Buildbot (0412 7D0B FABE C887 1FFB  2CCE 50E0 8855 93D2 DCB4)")
 	creationFlags.BoolVar(&sigVerify,
@@ -253,7 +255,7 @@ func runCreate(cmd *cobra.Command, args []string) {
 
 func unpackChroot(replace bool) {
 	plog.Noticef("Downloading SDK version %s", sdkVersion)
-	if err := sdk.DownloadSDK(sdkUrlPath, sdkVersion, verifyKeyFile); err != nil {
+	if err := sdk.DownloadSDK(sdkUrlPath, sdkVersion, verifyKeyFile, downloadImageJSONKeyFile); err != nil {
 		plog.Fatalf("Download failed: %v", err)
 	}
 

--- a/cmd/cork/download.go
+++ b/cmd/cork/download.go
@@ -30,6 +30,8 @@ var (
 	downloadUrl           string
 	downloadVersion       string
 	downloadVerifyKeyFile string
+	// downloadJSONKeyFile is used to access a private GCS bucket.
+	downloadJSONKeyFile string
 )
 
 func init() {
@@ -39,6 +41,8 @@ func init() {
 		"sdk-version", "", "SDK version")
 	downloadCmd.Flags().StringVar(&downloadImageVerifyKeyFile,
 		"verify-key", "", "PGP public key to be used in verifing download signatures.  Defaults to CoreOS Buildbot (0412 7D0B FABE C887 1FFB  2CCE 50E0 8855 93D2 DCB4)")
+	downloadCmd.Flags().StringVar(&downloadJSONKeyFile,
+		"json-key", "", "Google service account key for use with private buckets")
 	root.AddCommand(downloadCmd)
 }
 
@@ -52,7 +56,7 @@ func runDownload(cmd *cobra.Command, args []string) {
 	}
 
 	plog.Noticef("Downloading SDK version %s", downloadVersion)
-	if err := sdk.DownloadSDK(downloadUrl, downloadVersion, downloadVerifyKeyFile); err != nil {
+	if err := sdk.DownloadSDK(downloadUrl, downloadVersion, downloadVerifyKeyFile, downloadImageJSONKeyFile); err != nil {
 		plog.Fatalf("Download failed: %v", err)
 	}
 }


### PR DESCRIPTION
In this PR, we add the `--json-key` flag to `create` and `download` subcommands from `cork`. It allows a user to pass a GCS credential file path to `cork` in order to download from a private GCS bucket.

`update` command use the flags from the creation flags set, so no need to update this part:
```go
updateCmd.Flags().AddFlagSet(creationFlags)
```
## Testing done
```
$ ./bin/cork create --verbose --sdk-url-path "/flatcar-jenkins/sdk"
2021-10-04T16:11:35Z cli: Started logging at level INFO
2021-10-04T16:11:35Z cork: Detecting SDK version
2021-10-04T16:11:36Z cork: Found SDK version 3005.0.0 from remote repo
2021-10-04T16:11:36Z cork: Downloading SDK version 3005.0.0
2021-10-04T16:11:36Z sdk: Downloading https://storage.googleapis.com/flatcar-jenkins/sdk/amd64/3005.0.0/flatcar-sdk-amd64-3005.0.0.tar.bz2 to /home/mathieu/go/src/github.com/kinvolk/mantle/.cache/sdks/flatcar-sdk-amd64-3005.0.0.tar.bz2
2021-10-04T16:11:41Z cork: Download failed: 403 Forbidden: https://storage.googleapis.com/flatcar-jenkins/sdk/amd64/3005.0.0/flatcar-sdk-amd64-3005.0.0.tar.bz2
$ ./bin/cork create --json-key=$HOME/.gce/release.json --verbose
2021-10-04T16:05:55Z cli: Started logging at level INFO
2021-10-04T16:05:55Z cork: Detecting SDK version
2021-10-04T16:05:56Z cork: Found SDK version 3005.0.0 from remote repo
2021-10-04T16:05:56Z cork: Downloading SDK version 3005.0.0
2021-10-04T16:05:56Z sdk: Downloading https://storage.googleapis.com/flatcar-jenkins/sdk/amd64/3005.0.0/flatcar-sdk-amd64-3005.0.0.tar.bz2 to /home/mathieu/go/src/github.com/kinvolk/mantle/.cache/sdks/flatcar-sdk-amd64-3005.0.0.tar.bz2
2021-10-04T16:05:56Z sdk: Resuming from byte 21495808
^Catcar-sdk-amd64-3005.0.0.tar.bz2: [                          ] 36.1 MB/1.34 GB
``` 
