### PR TITLE
cork: add `--sdk-url`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - docker logs forwarding to `journald` for `kubeadm.*` tests ([#228](https://github.com/kinvolk/mantle/pull/228))
 - `OEM` ignitions tests ([#235](https://github.com/flatcar-linux/mantle/pull/235))
 - `--json-key` to `cork/create` and `cork/download` subcommands ([#239](https://github.com/flatcar-linux/mantle/pull/239))
+- `--sdk-url` to allow passing a SDK location ([#240](https://github.com/flatcar-linux/mantle/pull/240))
 
 ### Changed
 - Enabled SELinux for ARM64 ([#222](https://github.com/kinvolk/mantle/pull/222/))

--- a/cmd/cork/create.go
+++ b/cmd/cork/create.go
@@ -47,8 +47,10 @@ var (
 	chrootName  string
 
 	// creation flags
-	creationFlags  *pflag.FlagSet
-	sdkUrlPath     string
+	creationFlags *pflag.FlagSet
+	sdkUrlPath    string
+	// sdkURL is the URL targetting the SDK.
+	sdkURL         string
 	sdkVersion     string
 	manifestURL    string
 	manifestName   string
@@ -122,7 +124,9 @@ func init() {
 
 	creationFlags = pflag.NewFlagSet("creation", pflag.ExitOnError)
 	creationFlags.StringVar(&sdkUrlPath,
-		"sdk-url-path", "/flatcar-jenkins/sdk", "SDK URL path")
+		"sdk-url-path", "sdk", "SDK URL path")
+	creationFlags.StringVar(&sdkURL,
+		"sdk-url", "mirror.release.flatcar-linux.net", "SDK URL (supported schema: gs, https)")
 	creationFlags.StringVar(&sdkVersion,
 		"sdk-version", "", "SDK version. Defaults to the SDK version in version.txt")
 	creationFlags.StringVar(&manifestURL,
@@ -255,7 +259,7 @@ func runCreate(cmd *cobra.Command, args []string) {
 
 func unpackChroot(replace bool) {
 	plog.Noticef("Downloading SDK version %s", sdkVersion)
-	if err := sdk.DownloadSDK(sdkUrlPath, sdkVersion, verifyKeyFile, downloadImageJSONKeyFile); err != nil {
+	if err := sdk.DownloadSDK(sdkURL, sdkUrlPath, sdkVersion, verifyKeyFile, downloadImageJSONKeyFile); err != nil {
 		plog.Fatalf("Download failed: %v", err)
 	}
 

--- a/cmd/cork/download.go
+++ b/cmd/cork/download.go
@@ -27,6 +27,7 @@ var (
 		Long:  "Download the current SDK tarball to a local cache.",
 		Run:   runDownload,
 	}
+	URL                   string
 	downloadUrl           string
 	downloadVersion       string
 	downloadVerifyKeyFile string
@@ -35,8 +36,10 @@ var (
 )
 
 func init() {
+	downloadCmd.Flags().StringVar(&URL,
+		"sdk-url", "mirror.release.flatcar-linux.net", "SDK URL")
 	downloadCmd.Flags().StringVar(&downloadUrl,
-		"sdk-url-path", "/flatcar-jenkins/sdk", "SDK URL path")
+		"sdk-url-path", "sdk", "SDK URL path")
 	downloadCmd.Flags().StringVar(&downloadVersion,
 		"sdk-version", "", "SDK version")
 	downloadCmd.Flags().StringVar(&downloadImageVerifyKeyFile,
@@ -56,7 +59,7 @@ func runDownload(cmd *cobra.Command, args []string) {
 	}
 
 	plog.Noticef("Downloading SDK version %s", downloadVersion)
-	if err := sdk.DownloadSDK(downloadUrl, downloadVersion, downloadVerifyKeyFile, downloadImageJSONKeyFile); err != nil {
+	if err := sdk.DownloadSDK(URL, downloadUrl, downloadVersion, downloadVerifyKeyFile, downloadImageJSONKeyFile); err != nil {
 		plog.Fatalf("Download failed: %v", err)
 	}
 }

--- a/sdk/download.go
+++ b/sdk/download.go
@@ -35,10 +35,6 @@ import (
 	"github.com/coreos/mantle/util"
 )
 
-const (
-	urlHost = "storage.googleapis.com"
-)
-
 var plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "sdk")
 
 func TarballName(version string) string {
@@ -46,7 +42,7 @@ func TarballName(version string) string {
 	return fmt.Sprintf("flatcar-sdk-%s-%s.tar.bz2", arch, version)
 }
 
-func TarballURL(urlPath, version string) string {
+func TarballURL(urlHost, urlPath, version string) string {
 	arch := system.PortageArch()
 	p := path.Join(urlPath, arch, version, TarballName(version))
 	u := url.URL{Scheme: "https", Host: urlHost, Path: p}
@@ -196,9 +192,9 @@ func DownloadSignedFile(file, url string, client *http.Client, verifyKeyFile str
 	return nil
 }
 
-func DownloadSDK(urlPath, version, verifyKeyFile, JSONKeyFile string) error {
+func DownloadSDK(urlHost, urlPath, version, verifyKeyFile, JSONKeyFile string) error {
 	tarFile := filepath.Join(RepoCache(), "sdks", TarballName(version))
-	tarURL := TarballURL(urlPath, version)
+	tarURL := TarballURL(urlHost, urlPath, version)
 
 	var client *http.Client = nil
 	if len(JSONKeyFile) != 0 {


### PR DESCRIPTION
This PR superseeds #238 - we add a new flag `--sdk-url` in order to provide more flexibility.

It defaults to `mirror.release.flatcar-linux.net` for the UX.

## Testing done

```
$ ./bin/cork create --verbose
2021-10-05T10:42:14Z cli: Started logging at level INFO
2021-10-05T10:42:14Z cork: Detecting SDK version
2021-10-05T10:42:14Z cork: Found SDK version 3005.0.0 from remote repo
2021-10-05T10:42:14Z cork: Downloading SDK version 3005.0.0
2021-10-05T10:42:14Z sdk: Downloading https://mirror.release.flatcar-linux.net/sdk/amd64/3005.0.0/flatcar-sdk-amd64-3005.0.0.tar.bz2 to /home/mathieu/go/src/github.com/kinvolk/mantle/.cache/sdks/flatcar-sdk-amd64-3005.0.0.tar.bz2
2021-10-05T10:42:14Z sdk: Resuming from byte 7405568
^Catcar-sdk-amd64-3005.0.0.tar.bz2: [                          ] 23.5 MB/1.36 GB
$ ./bin/cork create --json-key=$HOME/.gce/release.json --verbose --sdk-url storage.googleapis.com --sdk-url-path "/flatcar-jenkins/sdk"
2021-10-05T10:45:01Z cli: Started logging at level INFO
2021-10-05T10:45:01Z cork: Detecting SDK version
2021-10-05T10:45:03Z cork: Found SDK version 3005.0.0 from remote repo
2021-10-05T10:45:03Z cork: Downloading SDK version 3005.0.0
2021-10-05T10:45:03Z sdk: Downloading https://storage.googleapis.com/flatcar-jenkins/sdk/amd64/3005.0.0/flatcar-sdk-amd64-3005.0.0.tar.bz2 to /home/mathieu/go/src/github.com/kinvolk/mantle/.cache/sdks/flatcar-sdk-amd64-3005.0.0.tar.bz2
^Catcar-sdk-amd64-3005.0.0.tar.bz2: [=                         ] 53.7 MB/1.37 GB
```
