### PR TITLE
plume: Enable the ARM64 board for Beta channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - kola: add raid0 tests for root and data devices ([#36](https://github.com/flatcar-linux/mantle/pull/36))
 - kola: Update the EM options to use sv15 region, c3.small plan ([#248](https://github.com/flatcar-linux/mantle/pull/248))
+- plume: Enable arm64 board uploads for the Beta channel ([#249](https://github.com/flatcar-linux/mantle/pull/249))
 
 ### Changed
 - `lsblk --json` output handling ([#244](https://github.com/flatcar-linux/mantle/pull/244))

--- a/cmd/plume/containerlinux.go
+++ b/cmd/plume/containerlinux.go
@@ -111,7 +111,7 @@ var (
 		"beta": channelSpec{
 			BaseURL:        "gs://flatcar-jenkins/beta/boards",
 			BasePrivateURL: "gs://flatcar-jenkins-private/beta/boards",
-			Boards:         []string{"amd64-usr"},
+			Boards:         []string{"amd64-usr", "arm64-usr"},
 			Destinations:   []storageSpec{},
 			GCE:            newGceSpec("beta", beta_desc),
 			Azure:          newAzureSpec(azureEnvironments, "publish", "Flatcar Beta", "", beta_desc),


### PR DESCRIPTION
# plume: Enable the ARM64 board for Beta channel

Without this the pre-release step for the Beta channel would fail, and no kola tests can be done.

Signed-off-by: Sayan Chowdhury <schowdhury@microsoft.com>

## Testing done

Not tested, but built locally.
