### PR TITLE
platform: enable enforcing mode SELinux earlier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `lsblk --json` output handling ([#244](https://github.com/flatcar-linux/mantle/pull/244))
 - Flannel version to 0.14.0 ([#245](https://github.com/flatcar-linux/mantle/pull/245))
 - Renamed the project name from `github.com/coreos/mantle` to `github.com/flatcar-linux/mantle` ([#241](https://github.com/flatcar-linux/mantle/pull/241))
+- SELinux is now enabled earlier in the boot process([#252](https://github.com/flatcar-linux/mantle/pull/252))
 
 ### Removed
 - Legacy Kola Kubernetes tests ([#250](https://github.com/flatcar-linux/mantle/pull/250))

--- a/platform/cluster.go
+++ b/platform/cluster.go
@@ -173,6 +173,25 @@ func (bc *BaseCluster) RenderUserData(userdata *conf.UserData, ignitionVars map[
 		conf.CopyKeys(keys)
 	}
 
+	if !bc.rconf.NoEnableSelinux {
+		selinuxConf := `# This file controls the state of SELinux on the system on boot.
+# SELINUX can take one of these three values:
+#	enforcing - SELinux security policy is enforced.
+#	permissive - SELinux prints warnings instead of enforcing.
+#	disabled - No SELinux policy is loaded.
+SELINUX=enforcing
+
+# SELINUXTYPE can take one of these four values:
+#	targeted - Only targeted network daemons are protected.
+#	strict   - Full SELinux protection.
+#	mls      - Full SELinux protection with Multi-Level Security
+#	mcs      - Full SELinux protection with Multi-Category Security
+#	           (mls, but only one sensitivity level)
+SELINUXTYPE=mcs
+`
+		conf.AddFile("/etc/selinux/config", "root", selinuxConf, 0644)
+	}
+
 	// disable Zincati & Pinger by default
 	if bc.Distribution() == "fcos" {
 		conf.AddFile("/etc/fedora-coreos-pinger/config.d/90-disable-reporting.toml", "root", `[reporting]

--- a/platform/util.go
+++ b/platform/util.go
@@ -81,22 +81,6 @@ func Manhole(m Machine) error {
 	return nil
 }
 
-// Enable SELinux on a machine (skip on machines without SELinux support)
-func EnableSelinux(m Machine) error {
-	_, stderr, err := m.SSH("sudo setenforce 1")
-	if err != nil {
-		return fmt.Errorf("Unable to enable SELinux: %s: %s", err, stderr)
-	}
-
-	// remove audit rules to get SELinux AVCs in the audit logs
-	_, stderr, err = m.SSH("sudo rm -rf /etc/audit/rules.d/{80-selinux.rules,99-default.rules}; sudo systemctl restart audit-rules")
-	if err != nil {
-		return fmt.Errorf("unable to enable SELinux audit logs: %s: %s", err, stderr)
-	}
-
-	return nil
-}
-
 // Reboots a machine, stopping ssh first.
 // Afterwards run CheckMachine to verify the system is back and operational.
 func StartReboot(m Machine) error {
@@ -128,11 +112,6 @@ func StartMachine(m Machine, j *Journal) error {
 	}
 	if err := CheckMachine(context.TODO(), m); err != nil {
 		return fmt.Errorf("machine %q failed basic checks: %v", m.ID(), err)
-	}
-	if !m.RuntimeConf().NoEnableSelinux {
-		if err := EnableSelinux(m); err != nil {
-			return fmt.Errorf("machine %q failed to enable selinux: %v", m.ID(), err)
-		}
 	}
 	return nil
 }


### PR DESCRIPTION
In this PR, we enable SELinux in enforcing mode earlier in the boot. Previously, it was done once the instance booted by running `sudo setenforce 1`.

By enabling and running all the tests with `enforcing` mode set as soon as possible during the boot, we'll be able to catch early denial from SElinux (like this one: https://github.com/flatcar-linux/coreos-overlay/pull/1426) which can prevent Flatcar to behave correctly.

## How to use

```
$ ./build kola
$ sudo ./bin/kola spawn --qemu-image ./flatcar_production_qemu_image.img
[bound] core@localhost ~ $ getenforce
Enforcing
[bound] core@localhost ~ $ sestatus
SELinux status:                 enabled
SELinuxfs mount:                /sys/fs/selinux
SELinux root directory:         /etc/selinux
Loaded policy name:             mcs
Current mode:                   enforcing
Mode from config file:          enforcing
Policy MLS status:              enabled
Policy deny_unknown status:     allowed
Memory protection checking:     actual (secure)
Max kernel policy version:      33
```

## Testing done

:warning: this needs to be merged after https://github.com/flatcar-linux/coreos-overlay/pull/1426 otherwise **all** tests using Docker runtime will fail with:
```
$ sudo ./bin/kola run --qemu-image ./flatcar_production_qemu_image.img docker.base
=== RUN   docker.base
=== RUN   docker.base/docker-info
=== RUN   docker.base/resources
=== RUN   docker.base/networks-reliably
=== RUN   docker.base/user-no-caps
--- FAIL: docker.base (20.79s)
    --- FAIL: docker.base/docker-info (0.13s)
            docker.go:573: could not get dockerinfo: Process exited with status 7
    --- FAIL: docker.base/resources (0.58s)
            cluster.go:117: The program docker is managed by torcx, which did not run.
...
```

with the patch proposed in https://github.com/flatcar-linux/coreos-overlay/pull/1426; it works fine:
```
$ sudo ./bin/kola run --qemu-image ./build/images/amd64-usr/developer-latest/flatcar_production_qemu_image.img docker.base
=== RUN   docker.base
=== RUN   docker.base/docker-info
=== RUN   docker.base/resources
=== RUN   docker.base/networks-reliably
=== RUN   docker.base/user-no-caps
--- PASS: docker.base (188.63s)
    --- PASS: docker.base/docker-info (1.28s)
    --- PASS: docker.base/resources (6.84s)
            cluster.go:117: WARNING: Your kernel does not support OomKillDisable. OomKillDisable discarded.
            cluster.go:117: WARNING: Specifying a kernel memory limit is deprecated and will be removed in a future release.
            cluster.go:117: WARNING: Your kernel does not support kernel memory limit capabilities or the cgroup is not mounted. Limitation discarded.
            cluster.go:117: WARNING: Your kernel does not support memory swappiness capabilities or the cgroup is not mounted. Memory swappiness discarded.
    --- PASS: docker.base/networks-reliably (157.16s)
    --- PASS: docker.base/user-no-caps (1.07s)
```