### PR TITLE
RenderUserData: only incject SELinux enforcing if there is userdata

### DIFF
--- a/platform/cluster.go
+++ b/platform/cluster.go
@@ -173,7 +173,7 @@ func (bc *BaseCluster) RenderUserData(userdata *conf.UserData, ignitionVars map[
 		conf.CopyKeys(keys)
 	}
 
-	if !bc.rconf.NoEnableSelinux {
+	if !bc.rconf.NoEnableSelinux && (conf.IsIgnition() || conf.IsCloudInit()) {
 		selinuxConf := `# This file controls the state of SELinux on the system on boot.
 # SELINUX can take one of these three values:
 #	enforcing - SELinux security policy is enforced.

--- a/platform/conf/conf.go
+++ b/platform/conf/conf.go
@@ -896,6 +896,10 @@ func (c *Conf) IsIgnition() bool {
 	return c.ignitionV1 != nil || c.ignitionV2 != nil || c.ignitionV21 != nil || c.ignitionV22 != nil || c.ignitionV23 != nil || c.ignitionV3 != nil
 }
 
+func (c *Conf) IsCloudInit() bool {
+	return c.cloudconfig != nil
+}
+
 func (c *Conf) IsEmpty() bool {
 	return !c.IsIgnition() && c.cloudconfig == nil && c.script == ""
 }


### PR DESCRIPTION
Some tests use machines without userdata and in this case there is no
way to inject it and the test should rather use a minimal dummy
Ignition config to enforce SELinux if it's relevant.

Don't try to inject SELinux enforcement in case no userdata is present
because the function panics in this case.


## How to use

Should fix the panic for `systemd.journal.remote`

## Testing done

`make test`