### PR TITLE
platform: revert early enforced SELinux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `lsblk --json` output handling ([#244](https://github.com/flatcar-linux/mantle/pull/244))
 - Flannel version to 0.14.0 ([#245](https://github.com/flatcar-linux/mantle/pull/245))
 - Renamed the project name from `github.com/coreos/mantle` to `github.com/flatcar-linux/mantle` ([#241](https://github.com/flatcar-linux/mantle/pull/241))
-- SELinux is now enabled earlier in the boot process([#252](https://github.com/flatcar-linux/mantle/pull/252))
 
 ### Removed
 - Legacy Kola Kubernetes tests ([#250](https://github.com/flatcar-linux/mantle/pull/250))

--- a/platform/cluster.go
+++ b/platform/cluster.go
@@ -173,25 +173,6 @@ func (bc *BaseCluster) RenderUserData(userdata *conf.UserData, ignitionVars map[
 		conf.CopyKeys(keys)
 	}
 
-	if !bc.rconf.NoEnableSelinux {
-		selinuxConf := `# This file controls the state of SELinux on the system on boot.
-# SELINUX can take one of these three values:
-#	enforcing - SELinux security policy is enforced.
-#	permissive - SELinux prints warnings instead of enforcing.
-#	disabled - No SELinux policy is loaded.
-SELINUX=enforcing
-
-# SELINUXTYPE can take one of these four values:
-#	targeted - Only targeted network daemons are protected.
-#	strict   - Full SELinux protection.
-#	mls      - Full SELinux protection with Multi-Level Security
-#	mcs      - Full SELinux protection with Multi-Category Security
-#	           (mls, but only one sensitivity level)
-SELINUXTYPE=mcs
-`
-		conf.AddFile("/etc/selinux/config", "root", selinuxConf, 0644)
-	}
-
 	// disable Zincati & Pinger by default
 	if bc.Distribution() == "fcos" {
 		conf.AddFile("/etc/fedora-coreos-pinger/config.d/90-disable-reporting.toml", "root", `[reporting]

--- a/platform/cluster.go
+++ b/platform/cluster.go
@@ -173,7 +173,7 @@ func (bc *BaseCluster) RenderUserData(userdata *conf.UserData, ignitionVars map[
 		conf.CopyKeys(keys)
 	}
 
-	if !bc.rconf.NoEnableSelinux && (conf.IsIgnition() || conf.IsCloudInit()) {
+	if !bc.rconf.NoEnableSelinux {
 		selinuxConf := `# This file controls the state of SELinux on the system on boot.
 # SELINUX can take one of these three values:
 #	enforcing - SELinux security policy is enforced.

--- a/platform/conf/conf.go
+++ b/platform/conf/conf.go
@@ -896,10 +896,6 @@ func (c *Conf) IsIgnition() bool {
 	return c.ignitionV1 != nil || c.ignitionV2 != nil || c.ignitionV21 != nil || c.ignitionV22 != nil || c.ignitionV23 != nil || c.ignitionV3 != nil
 }
 
-func (c *Conf) IsCloudInit() bool {
-	return c.cloudconfig != nil
-}
-
 func (c *Conf) IsEmpty() bool {
 	return !c.IsIgnition() && c.cloudconfig == nil && c.script == ""
 }

--- a/platform/util.go
+++ b/platform/util.go
@@ -81,6 +81,22 @@ func Manhole(m Machine) error {
 	return nil
 }
 
+// Enable SELinux on a machine (skip on machines without SELinux support)
+func EnableSelinux(m Machine) error {
+	_, stderr, err := m.SSH("sudo setenforce 1")
+	if err != nil {
+		return fmt.Errorf("Unable to enable SELinux: %s: %s", err, stderr)
+	}
+
+	// remove audit rules to get SELinux AVCs in the audit logs
+	_, stderr, err = m.SSH("sudo rm -rf /etc/audit/rules.d/{80-selinux.rules,99-default.rules}; sudo systemctl restart audit-rules")
+	if err != nil {
+		return fmt.Errorf("unable to enable SELinux audit logs: %s: %s", err, stderr)
+	}
+
+	return nil
+}
+
 // Reboots a machine, stopping ssh first.
 // Afterwards run CheckMachine to verify the system is back and operational.
 func StartReboot(m Machine) error {
@@ -112,6 +128,11 @@ func StartMachine(m Machine, j *Journal) error {
 	}
 	if err := CheckMachine(context.TODO(), m); err != nil {
 		return fmt.Errorf("machine %q failed basic checks: %v", m.ID(), err)
+	}
+	if !m.RuntimeConf().NoEnableSelinux {
+		if err := EnableSelinux(m); err != nil {
+			return fmt.Errorf("machine %q failed to enable selinux: %v", m.ID(), err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
In this PR, we remove the patches introduced in:
* #252 
* #253 

These patches force the usage of enforced SELinux earlier in the boot to cover more processes.

We need to remove them temporary due to this kind of error:
 > Error: "cluster.go:117: The program docker is managed by torcx, which did not run.\n        cluster.go:130: \"sudo mkdir /etc/misc && \\\\\\ndocker run -v \\\"/etc/misc:/opt\\\" --rm ghcr.io/kinvolk/busybox true\" failed: output , status Process exited with status 1"

which should be fixed by https://github.com/flatcar-linux/coreos-overlay/commit/9380a02531873ba7f92805f6faf9c7ccc9008e7c but for an unknown reason yet it does not work as expected.
