### PR TITLE
plume: Use the public bucket proxy for anonymous access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - kola: add raid0 tests for root and data devices ([#36](https://github.com/flatcar-linux/mantle/pull/36))
 - kola: Update the EM options to use sv15 region, c3.small plan ([#248](https://github.com/flatcar-linux/mantle/pull/248))
 - plume: Enable arm64 board uploads for the Beta channel ([#249](https://github.com/flatcar-linux/mantle/pull/249))
+- plume: Restore anonymous access with `--gce-json-key none` ([#255](https://github.com/flatcar-linux/mantle/pull/255))
 
 ### Changed
 - `lsblk --json` output handling ([#244](https://github.com/flatcar-linux/mantle/pull/244))

--- a/cmd/plume/containerlinux.go
+++ b/cmd/plume/containerlinux.go
@@ -309,6 +309,9 @@ func (cs channelSpec) SourceURL() string {
 	if specPrivateBucket {
 		baseURL = cs.BasePrivateURL
 	}
+	if gceJSONKeyFile == "none" {
+		baseURL = strings.Replace(baseURL, "gs://", "https://bucket.release.flatcar-linux.net/", 1)
+	}
 
 	u, err := url.Parse(baseURL)
 	if err != nil {

--- a/cmd/plume/prerelease.go
+++ b/cmd/plume/prerelease.go
@@ -147,7 +147,7 @@ func runCLPreRelease(cmd *cobra.Command) error {
 		plog.Fatal(err)
 	}
 
-	if err := src.Fetch(ctx); err != nil {
+	if err := src.Fetch(ctx); err != nil && !strings.HasPrefix(spec.SourceURL(), "http") {
 		plog.Fatal(err)
 	}
 

--- a/cmd/plume/release.go
+++ b/cmd/plume/release.go
@@ -81,7 +81,7 @@ func runCLRelease(cmd *cobra.Command, args []string) error {
 	}
 	src.WriteDryRun(releaseDryRun)
 
-	if err := src.Fetch(ctx); err != nil {
+	if err := src.Fetch(ctx); err != nil && !strings.HasPrefix(spec.SourceURL(), "http") {
 		plog.Fatal(err)
 	}
 

--- a/storage/bucket_test.go
+++ b/storage/bucket_test.go
@@ -37,7 +37,7 @@ func (b *Bucket) AddObject(obj *storage.Object) {
 }
 
 func TestBucketURL(t *testing.T) {
-	if _, err := FakeBucket("http://bucket/"); err != UnknownScheme {
+	if _, err := FakeBucket("sftp://bucket/"); err != UnknownScheme {
 		t.Errorf("Unexpected error: %v", err)
 	}
 


### PR DESCRIPTION
The image download from the bucket is not possible anymore directly but
needs to be done through the HTTP proxy.  

Create a limited bucket object for anonymous access, which can only
download particular files and has no listing or	upload ability.
Calling code needs to make sure it only tries uploads or directory
listings when the bucket object is using a proper gs:// URL and that
it configured credentials before trying to upload.


## How to use


## Testing done

```
bin/plume pre-release --gce-json-key none --aws-credentials /dev/null --platform aws -d --version 2983.2.0 --channel stable -P china
```