### PR TITLE
api/packet: change default server spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `lsblk --json` output handling ([#244](https://github.com/flatcar-linux/mantle/pull/244))
 - Flannel version to 0.14.0 ([#245](https://github.com/flatcar-linux/mantle/pull/245))
 - Renamed the project name from `github.com/coreos/mantle` to `github.com/flatcar-linux/mantle` ([#241](https://github.com/flatcar-linux/mantle/pull/241))
+- Default server for AMD64 on Equinix Metal ([#256](https://github.com/flatcar-linux/mantle/pull/256))
 
 ### Removed
 - Legacy Kola Kubernetes tests ([#250](https://github.com/flatcar-linux/mantle/pull/250))

--- a/platform/api/packet/api.go
+++ b/platform/api/packet/api.go
@@ -63,7 +63,7 @@ var (
 		"arm64-usr": "https://alpha.release.flatcar-linux.net/arm64-usr/current/flatcar_production_packet_image.bin.bz2",
 	}
 	defaultPlan = map[string]string{
-		"amd64-usr": "baremetal_0",
+		"amd64-usr": "c3.small.x86",
 		"arm64-usr": "c2.large.arm",
 	}
 	linuxConsole = map[string]string{


### PR DESCRIPTION
`baremetal_0/t1.small` servers are now deprecated and no more available
in facilities.

We update to a newer server spec by default: `c3.small.x86`

See also: https://metal.equinix.com/developers/docs/servers/server-specs/#server-specs

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>
