### PR TITLE
api/packet: change default ARM server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `lsblk --json` output handling ([#244](https://github.com/flatcar-linux/mantle/pull/244))
 - Flannel version to 0.14.0 ([#245](https://github.com/flatcar-linux/mantle/pull/245))
 - Renamed the project name from `github.com/coreos/mantle` to `github.com/flatcar-linux/mantle` ([#241](https://github.com/flatcar-linux/mantle/pull/241))
-- Default server for AMD64 on Equinix Metal ([#256](https://github.com/flatcar-linux/mantle/pull/256))
+- Default server on Equinix Metal ([#256](https://github.com/flatcar-linux/mantle/pull/256), [#257](https://github.com/flatcar-linux/mantle/pull/257))
 
 ### Removed
 - Legacy Kola Kubernetes tests ([#250](https://github.com/flatcar-linux/mantle/pull/250))

--- a/platform/api/packet/api.go
+++ b/platform/api/packet/api.go
@@ -64,7 +64,7 @@ var (
 	}
 	defaultPlan = map[string]string{
 		"amd64-usr": "c3.small.x86",
-		"arm64-usr": "c2.large.arm",
+		"arm64-usr": "c3.large.arm",
 	}
 	linuxConsole = map[string]string{
 		"amd64-usr": "ttyS1,115200n8",


### PR DESCRIPTION
`c2.large.arm` are deprecated too and CI is failing with:
```
2021-11-22T09:31:56Z kola: creating new machine for semver check: couldn't create device: POST https://api.packet.net/projects/2c850bb4-70b4-4dcd-b60f-2d0be86d0ae4/devices: 422 No available servers with plan c2.large.arm in facility sv15
```

`c2.large.arm` is deprecated in favor of: `c3.large.arm`.

See also: https://metal.equinix.com/developers/docs/servers/server-specs/#c3largearm

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>
