### PR TITLE
Equinix Metal: Don't wait for /dev/sda when installing

### DIFF
--- a/platform/api/packet/api.go
+++ b/platform/api/packet/api.go
@@ -340,11 +340,11 @@ Description=Install Container Linux
 Requires=network-online.target
 After=network-online.target
 
-Requires=dev-sda.device
-After=dev-sda.device
-
 [Service]
 Type=oneshot
+Restart=on-failure
+RemainAfterExit=true
+RestartSec=3s
 # Prevent flatcar-install from validating cloud-config
 Environment=PATH=/root/bin:/usr/sbin:/usr/bin
 


### PR DESCRIPTION
Some instance types like the c3.large.arm have only a single NVMe disk
and the installer waits endlessly for /dev/sda while it's not required.

Remove the waiting for /dev/sda from the installer service unit and
make it be restarted in case of errors, like not having found a
suitable disk.

## How to use

See that a test can run on c3.large.arm

## Testing done

This here passed fine:
```
./kola run -k -d --basename=jenkins-831 --board=arm64-usr --channel=beta --gce-json-key=… --packet-api-key=… --packet-facility=da11 --packet-image-url=https://bucket.release.flatcar-linux.net/flatcar-jenkins/beta/boards/arm64-usr/3033.1.1/flatcar_production_packet_image.bin.bz2 --packet-installer-image-kernel-url=http://bucket.release.flatcar-linux.net/flatcar-jenkins/beta/boards/arm64-usr/3033.1.1/flatcar_production_pxe.vmlinuz --packet-installer-image-cpio-url=http://bucket.release.flatcar-linux.net/flatcar-jenkins/beta/boards/arm64-usr/3033.1.1/flatcar_production_pxe_image.cpio.gz --packet-project=… --packet-storage-url=gs://flatcar-jenkins/mantle/packet --packet-plan=  --platform=packet  cl.basic
```