### PR TITLE
kola/tests/etcd: add `name: ` to one CLC

### DIFF
--- a/kola/tests/etcd/discovery.go
+++ b/kola/tests/etcd/discovery.go
@@ -16,8 +16,10 @@ package etcd
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/coreos/pkg/capnslog"
+	"github.com/pborman/uuid"
 
 	"github.com/flatcar-linux/mantle/kola/cluster"
 	"github.com/flatcar-linux/mantle/kola/register"
@@ -65,14 +67,14 @@ etcd:
 		// this lets it run on more platforms, and also faster
 		ClusterSize: 1,
 		Name:        "cl.etcd-member.etcdctlv3",
-		UserData: conf.ContainerLinuxConfig(`
-
+		UserData: conf.ContainerLinuxConfig(fmt.Sprintf(`
 etcd:
+  name:                        kola-etcd-member-%s
   listen_client_urls:          http://0.0.0.0:2379
   advertise_client_urls:       http://127.0.0.1:2379
   listen_peer_urls:            http://0.0.0.0:2380
   initial_advertise_peer_urls: http://127.0.0.1:2380
-`),
+`, uuid.New())),
 		Distros:          []string{"cl"},
 		ExcludePlatforms: []string{"qemu-unpriv"},
 	})


### PR DESCRIPTION
Using both command line option and environment variable is forbidden
since `etcd/v3`.

It happens quite a lot that user override default `etcd` name
(`machine-id`) using `CLC` through the `name: ` key.
In this case it fails because we will have both `ETCD_NAME`
and `--name` in the runtime.

This patch overrides the name in CLC in order to reproduce this behavior
and prevent regression in the next release.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

This test is currently failing with current releases - it has to be merged with https://github.com/flatcar-linux/coreos-overlay/pull/1444.

Changelog entry is not required IMHO.
