### PR TITLE
test: add bpf test with DNS gadget from local-gadget 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - kola: Update the EM options to use sv15 region, c3.small plan ([#248](https://github.com/flatcar-linux/mantle/pull/248))
 - plume: Enable arm64 board uploads for the Beta channel ([#249](https://github.com/flatcar-linux/mantle/pull/249))
 - plume: Restore anonymous access with `--gce-json-key none` ([#255](https://github.com/flatcar-linux/mantle/pull/255))
+- BPF test with DNS gadget from Inspektor Gadget ([#260](https://github.com/flatcar-linux/mantle/pull/260))
 
 ### Changed
 - `lsblk --json` output handling ([#244](https://github.com/flatcar-linux/mantle/pull/244))

--- a/kola/registry/registry.go
+++ b/kola/registry/registry.go
@@ -2,6 +2,7 @@ package registry
 
 // Tests imported for registration side effects. These make up the OS test suite and is explicitly imported from the main package.
 import (
+	_ "github.com/flatcar-linux/mantle/kola/tests/bpf"
 	_ "github.com/flatcar-linux/mantle/kola/tests/coretest"
 	_ "github.com/flatcar-linux/mantle/kola/tests/crio"
 	_ "github.com/flatcar-linux/mantle/kola/tests/docker"

--- a/kola/tests/bpf/local-gadget.go
+++ b/kola/tests/bpf/local-gadget.go
@@ -1,0 +1,149 @@
+// Copyright The Mantle Authors.
+// SPDX-License-Identifier: Apache-2.0
+package bpf
+
+import (
+	"bytes"
+	"strings"
+	"text/template"
+
+	"github.com/flatcar-linux/mantle/kola"
+	"github.com/flatcar-linux/mantle/kola/cluster"
+	"github.com/flatcar-linux/mantle/kola/register"
+	"github.com/flatcar-linux/mantle/kola/tests/docker"
+	"github.com/flatcar-linux/mantle/platform/conf"
+)
+
+type gadget struct {
+	// Arch holds the gadget architecture (arm or amd).
+	Arch string
+	// Version holds the version of the gadget (v0.4.1 for example).
+	Version string
+	// Sum holds the SHA512 checksum to verify binary.
+	Sum string
+	// Cmd holds the command for the given gadget.
+	Cmd string
+}
+
+var (
+	// binaries holds the map of binaries for each supported
+	// architecture.
+	binaries = map[string]gadget{
+		"arm64": gadget{
+			Version: "0.4.1",
+			Sum:     "4b5761dd08afea378e7e58a5a76b76c727ed59d327e042a42dd72330cac7bcd516da7574f69d22a4076c07dcafa639d08aaced56cf624816c5815226b33a0961",
+		},
+		"amd64": gadget{
+			Version: "0.4.1",
+			Sum:     "d68c2c55ac3d783f52aaf9b2e360955fa542f48901b6dc7fc4d52cd91e22f5c9839e6dd89e575923f117752e82f052d397c002cdd9acbcc3adfb893b8a18cdd8",
+		},
+	}
+	config = `storage:
+  files:
+    - path: /opt/local-gadget.tar.gz
+      filesystem: root
+      mode: 0755
+      contents:
+        remote:
+          url: https://github.com/kinvolk/inspektor-gadget/releases/download/v{{ .Version }}/local-gadget-linux-{{ .Arch }}.tar.gz
+          verification:
+            hash:
+              function: sha512
+              sum: {{ .Sum }}
+    - path: /opt/local-gadget.cmd
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          {{ .Cmd }}
+systemd:
+  units:
+    - name: prepare-local-gadget.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Unpack local-gadget to /opt/bin/
+        ConditionPathExists=!/opt/bin/local-gadget
+        [Service]
+        Type=oneshot
+        RemainAfterExit=true
+        Restart=on-failure
+        ExecStartPre=/usr/bin/mkdir --parents /opt/bin
+        ExecStartPre=/usr/bin/tar -v --extract --file /opt/local-gadget.tar.gz --directory /opt/bin --no-same-owner
+        ExecStart=/usr/bin/rm /opt/local-gadget.tar.gz
+        [Install]
+        WantedBy=multi-user.target
+    - name: local-gadget.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Run local-gadget
+        After=prepare-local-gadget.service
+        Requires=prepare-local-gadget.service
+        [Service]
+        User=root
+        Type=fork
+        RemainAfterExit=true
+        Restart=on-failure
+        ExecStart=/opt/bin/local-gadget
+        StandardInput=file:/opt/local-gadget.cmd
+        StandardOutput=file:/tmp/local-gadget.res
+        [Install]
+        WantedBy=multi-user.target`
+)
+
+func init() {
+	register.Register(&register.Test{
+		Run:     localGadgetTest,
+		Name:    `bpf.local-gadget`,
+		Distros: []string{"cl"},
+		// required while SELinux policy is not correcly updated to support
+		// `bpf` and `perfmon` permission.
+		Flags: []register.Flag{register.NoEnableSelinux},
+	})
+}
+
+func localGadgetTest(c cluster.TestCluster) {
+	arch := strings.SplitN(kola.QEMUOptions.Board, "-", 2)[0]
+	gadget := binaries[arch]
+
+	gadget.Arch = arch
+
+	tmpl, err := template.New("user-data").Parse(config)
+	if err != nil {
+		c.Fatalf("parsing user-data: %w", err)
+	}
+
+	c.Run("dns gadget", func(c cluster.TestCluster) {
+		gadget.Cmd = `create dns kola-dns --container-selector=shell01
+          list-traces
+          stream -f kola-dns`
+
+		var buf bytes.Buffer
+		if err := tmpl.Execute(&buf, gadget); err != nil {
+			c.Fatalf("rendering user-data: %w", err)
+		}
+
+		node, err := c.NewMachine(conf.ContainerLinuxConfig(buf.String()))
+		if err != nil {
+			c.Fatalf("creating node: %v", err)
+		}
+
+		docker.GenDockerImage(c, node, "dig", []string{"dig"})
+
+		if _, err := c.SSH(node, "docker run --rm --name shell01 dig dig flatcar-linux.org"); err != nil {
+			c.Fatalf("unable to run docker cmd: %v", err)
+		}
+
+		out, err := c.SSH(node, "grep -m 1 pkt_type /tmp/local-gadget.res | jq -r .name")
+		if err != nil {
+			c.Fatalf("unable to get local-gadget res: %v", err)
+		}
+
+		name := string(out)
+
+		if name != "flatcar-linux.org." {
+			c.Fatalf("should have 'flatcar-linux.org.', got: %v", err)
+		}
+	})
+}

--- a/kola/tests/docker/docker.go
+++ b/kola/tests/docker/docker.go
@@ -232,8 +232,8 @@ systemd:
 	})
 }
 
-// make a docker container out of binaries on the host
-func genDockerContainer(c cluster.TestCluster, m platform.Machine, name string, binnames []string) {
+// make a docker image out of binaries on the host
+func GenDockerImage(c cluster.TestCluster, m platform.Machine, name string, binnames []string) {
 	cmd := `tmpdir=$(mktemp -d); cd $tmpdir; echo -e "FROM scratch\nCOPY . /" > Dockerfile;
 	        b=$(which %s); libs=$(sudo ldd $b | grep -o /lib'[^ ]*' | sort -u);
 	        sudo rsync -av --relative --copy-links $b $libs ./;
@@ -258,7 +258,7 @@ func dockerBaseTests(c cluster.TestCluster) {
 func dockerResources(c cluster.TestCluster) {
 	m := c.Machines()[0]
 
-	genDockerContainer(c, m, "sleep", []string{"sleep"})
+	GenDockerImage(c, m, "sleep", []string{"sleep"})
 
 	dockerFmt := "docker run --rm %s sleep sleep 0.2"
 
@@ -326,8 +326,8 @@ func dockerNetwork(c cluster.TestCluster) {
 
 	c.Log("creating ncat containers")
 
-	genDockerContainer(c, src, "ncat", []string{"ncat"})
-	genDockerContainer(c, dest, "ncat", []string{"ncat"})
+	GenDockerImage(c, src, "ncat", []string{"ncat"})
+	GenDockerImage(c, dest, "ncat", []string{"ncat"})
 
 	listener := func(ctx context.Context) error {
 		// Will block until a message is recieved
@@ -401,7 +401,7 @@ func dockerOldClient(c cluster.TestCluster) {
 	}
 	c.DropFile(oldclient)
 
-	genDockerContainer(c, m, "echo", []string{"echo"})
+	GenDockerImage(c, m, "echo", []string{"echo"})
 
 	output := c.MustSSH(m, "/home/core/docker-1.9.1 run echo echo 'IT WORKED'")
 
@@ -414,7 +414,7 @@ func dockerOldClient(c cluster.TestCluster) {
 func dockerUserns(c cluster.TestCluster) {
 	m := c.Machines()[0]
 
-	genDockerContainer(c, m, "userns-test", []string{"echo", "sleep"})
+	GenDockerImage(c, m, "userns-test", []string{"echo", "sleep"})
 
 	output := c.MustSSH(m, `docker run userns-test echo fj.fj`)
 	if !bytes.Equal(output, []byte("fj.fj")) {
@@ -442,7 +442,7 @@ func dockerUserns(c cluster.TestCluster) {
 func dockerNetworksReliably(c cluster.TestCluster) {
 	m := c.Machines()[0]
 
-	genDockerContainer(c, m, "ping", []string{"sh", "ping"})
+	GenDockerImage(c, m, "ping", []string{"sh", "ping"})
 
 	output := c.MustSSH(m, `for i in $(seq 1 100); do
 		echo -n "$i: "
@@ -467,7 +467,7 @@ func dockerNetworksReliably(c cluster.TestCluster) {
 func dockerUserNoCaps(c cluster.TestCluster) {
 	m := c.Machines()[0]
 
-	genDockerContainer(c, m, "captest", []string{"capsh", "sh", "grep", "cat", "ls"})
+	GenDockerImage(c, m, "captest", []string{"capsh", "sh", "grep", "cat", "ls"})
 
 	output := c.MustSSH(m, `docker run --user 1000:1000 \
 		-v /root:/root \


### PR DESCRIPTION
In this PR, we test `IG` and related BPF features on Flatcar with `local-gadget` starting with DNS gadget.

We basically install `local-gadget` and prepare its run using CLC.

It currently runs without SELinux due to this: https://github.com/flatcar-linux/Flatcar/issues/509

## How to use

```
./build kola
./bin/kola list | grep gadget
bpf.local-gadget			[all]								[all]		[cl]		[all]		[all]
```

## Testing done


```
=== RUN   bpf.local-gadget
=== RUN   bpf.local-gadget/dns_gadget
--- PASS: bpf.local-gadget (20.63s)
    --- PASS: bpf.local-gadget/dns_gadget (18.47s)
PASS, output in _kola_temp/qemu-2021-12-01-1126-8837
```

Related-to: https://github.com/flatcar-linux/Flatcar/issues/89

It could be merged with: https://github.com/flatcar-linux/mantle/pull/233 to kickoff BPF tests on Flatcar.