### PR TITLE
kola/test/bpf: remove esx from supported platforms

### DIFF
--- a/kola/tests/bpf/local-gadget.go
+++ b/kola/tests/bpf/local-gadget.go
@@ -97,6 +97,9 @@ func init() {
 		Run:     localGadgetTest,
 		Name:    `bpf.local-gadget`,
 		Distros: []string{"cl"},
+		// ESX is excluded because initramfs has no network access
+		// so it's not able to download local-gadget binary.
+		ExcludePlatforms: []string{"esx"},
 		// required while SELinux policy is not correcly updated to support
 		// `bpf` and `perfmon` permission.
 		Flags: []register.Flag{register.NoEnableSelinux},


### PR DESCRIPTION
ESX initramfs does not have network access - `local-gadget` is not able
to be downloaded so the instance fails to boot.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

Changelog entry is not required.
