### PR TITLE
kola/test/bpf: remove `arm64` architecture

### DIFF
--- a/kola/tests/bpf/bpf.go
+++ b/kola/tests/bpf/bpf.go
@@ -40,6 +40,8 @@ func init() {
 		// required while SELinux policy is not correcly updated to support
 		// `bpf` and `perfmon` permission.
 		Flags: []register.Flag{register.NoEnableSelinux},
+		// exclude `arm64` while `quay.io/iovisor/bcc` does not have `arm64` support.
+		Architectures: []string{"amd64"},
 	})
 }
 


### PR DESCRIPTION
the docker image does not yet support `arm64` architecture so it fails
to run.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

No changelog entry required.
