### PR TITLE
cmd/plume: enable `arm64` support for stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - plume: Restore anonymous access with `--gce-json-key none` ([#255](https://github.com/flatcar-linux/mantle/pull/255))
 - BPF test with DNS gadget from Inspektor Gadget ([#260](https://github.com/flatcar-linux/mantle/pull/260))
 - BPF execsnoop test ([#233](https://github.com/flatcar-linux/mantle/pull/233))
+- plume: Enable arm64 board uploads for the Stable channel ([#266](https://github.com/flatcar-linux/mantle/pull/266))
 
 ### Changed
 - `lsblk --json` output handling ([#244](https://github.com/flatcar-linux/mantle/pull/244))

--- a/cmd/plume/containerlinux.go
+++ b/cmd/plume/containerlinux.go
@@ -121,7 +121,7 @@ var (
 		"stable": channelSpec{
 			BaseURL:        "gs://flatcar-jenkins/stable/boards",
 			BasePrivateURL: "gs://flatcar-jenkins-private/stable/boards",
-			Boards:         []string{"amd64-usr"},
+			Boards:         []string{"amd64-usr", "arm64-usr"},
 			Destinations:   []storageSpec{},
 			GCE:            newGceSpec("stable", stable_desc),
 			Azure:          newAzureSpec(azureEnvironments, "publish", "Flatcar Stable", "", stable_desc),


### PR DESCRIPTION
Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>


- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
