### PR TITLE
kola/test/bpf: exclude LTS from BPF supported channel

### DIFF
--- a/kola/tests/bpf/local-gadget.go
+++ b/kola/tests/bpf/local-gadget.go
@@ -103,6 +103,9 @@ func init() {
 		// required while SELinux policy is not correcly updated to support
 		// `bpf` and `perfmon` permission.
 		Flags: []register.Flag{register.NoEnableSelinux},
+		// current LTS has DOCKER_API_VERSION=1.40 which is too old for local-gadget docker client.
+		// "client version 1.41 is too new. Maximum supported API version is 1.40"
+		ExcludeChannels: []string{"lts"},
 	})
 }
 


### PR DESCRIPTION
`local-gadget` Docker client does not support API < 1.41 - in the
current LTS, API VERSION is equal to 1.40.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

No changelog required