### PR TITLE
equinix-metal: recycle existing instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - BPF test with DNS gadget from Inspektor Gadget ([#260](https://github.com/flatcar-linux/mantle/pull/260))
 - BPF execsnoop test ([#233](https://github.com/flatcar-linux/mantle/pull/233))
 - plume: Enable arm64 board uploads for the Stable channel ([#266](https://github.com/flatcar-linux/mantle/pull/266))
+- A way to reuse Equinix Metal devices during tests ([#268](https://github.com/flatcar-linux/mantle/pull/268))
 
 ### Changed
 - `lsblk --json` output handling ([#244](https://github.com/flatcar-linux/mantle/pull/244))

--- a/cmd/ore/packet/create-device.go
+++ b/cmd/ore/packet/create-device.go
@@ -71,7 +71,7 @@ func runCreateDevice(cmd *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 
-	device, err := API.CreateDevice(hostname, conf, nil)
+	device, err := API.CreateOrUpdateDevice(hostname, conf, nil, "")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Couldn't create device: %v\n", err)
 		os.Exit(1)

--- a/platform/machine/packet/cluster.go
+++ b/platform/machine/packet/cluster.go
@@ -98,37 +98,40 @@ func (pc *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 		mach.publicIP = pc.flight.api.GetDeviceAddress(device, 4, true)
 		mach.privateIP = pc.flight.api.GetDeviceAddress(device, 4, false)
 		if mach.publicIP == "" || mach.privateIP == "" {
-			mach.Destroy()
+			pc.flight.api.DeleteDevice(mach.ID())
 			err = fmt.Errorf("couldn't find IP addresses for device")
 			continue // provisioning error
 		}
 
+		// Warning: the assumption is that within one test a machine doesn't get reused
+		// (if a test would create, destroy and create a machine explicitly)
+		// otherwise the console file names will clash
 		dir := filepath.Join(pc.RuntimeConf().OutputDir, mach.ID())
 		if err = os.Mkdir(dir, 0777); err != nil {
-			mach.Destroy()
+			pc.flight.api.DeleteDevice(mach.ID())
 			return nil, err
 		}
 
 		if cons != nil {
 			if err = os.Rename(consolePath, filepath.Join(dir, "console.txt")); err != nil {
-				mach.Destroy()
+				pc.flight.api.DeleteDevice(mach.ID())
 				return nil, err
 			}
 		}
 
 		confPath := filepath.Join(dir, "user-data")
 		if err = conf.WriteFile(confPath); err != nil {
-			mach.Destroy()
+			pc.flight.api.DeleteDevice(mach.ID())
 			return nil, err
 		}
 
 		if mach.journal, err = platform.NewJournal(dir); err != nil {
-			mach.Destroy()
+			pc.flight.api.DeleteDevice(mach.ID())
 			return nil, err
 		}
 
 		if err = platform.StartMachine(mach, mach.journal); err != nil {
-			mach.Destroy()
+			pc.flight.api.DeleteDevice(mach.ID())
 			continue // provisioning error
 		}
 

--- a/platform/machine/packet/cluster.go
+++ b/platform/machine/packet/cluster.go
@@ -76,8 +76,16 @@ func (pc *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 			pcons = cons
 		}
 
-		// CreateDevice unconditionally closes console when done with it
-		device, err = pc.flight.api.CreateDevice(vmname, conf, pcons)
+		var id string
+		select {
+		case i := <-pc.flight.devicesPool:
+			id = i
+		default:
+			id = ""
+		}
+
+		// CreateOrUpdateDevice unconditionally closes console when done with it
+		device, err = pc.flight.api.CreateOrUpdateDevice(vmname, conf, pcons, id)
 		if err != nil {
 			continue // provisioning error
 		}

--- a/platform/machine/packet/console.go
+++ b/platform/machine/packet/console.go
@@ -16,6 +16,7 @@ package packet
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 
 	"golang.org/x/crypto/ssh"
@@ -30,7 +31,25 @@ type console struct {
 }
 
 func (c *console) SSHClient(ip, user string) (*ssh.Client, error) {
-	return c.pc.UserSSHClient(ip, user)
+	client, err := c.pc.UserSSHClient(ip, user)
+	if err != nil {
+		return nil, fmt.Errorf("getting SSH client: %w", err)
+	}
+
+	c.ssh = client
+	return client, nil
+}
+
+func (c *console) CloseSSH() error {
+	if c.ssh == nil {
+		return nil
+	}
+
+	if err := c.ssh.Close(); err != nil {
+		return fmt.Errorf("closing SSH client: %w", err)
+	}
+
+	return nil
 }
 
 func (c *console) Write(p []byte) (int, error) {

--- a/platform/machine/packet/console.go
+++ b/platform/machine/packet/console.go
@@ -26,6 +26,7 @@ type console struct {
 	f    *os.File
 	buf  bytes.Buffer
 	done chan interface{}
+	ssh  *ssh.Client
 }
 
 func (c *console) SSHClient(ip, user string) (*ssh.Client, error) {


### PR DESCRIPTION
In this PR, we add the ability to mantle test to reuse existing Equinix Metal instances and to keep them into a pool of devices in the Flight lifecycle.

<hr>

Closes: https://github.com/flatcar-linux/Flatcar/issues/551

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
