### PR TITLE
platform/machine/em: check if console is created

### DIFF
--- a/platform/machine/packet/machine.go
+++ b/platform/machine/packet/machine.go
@@ -75,8 +75,10 @@ func (pm *machine) Destroy() {
 	// The serial console SSH client needs to be manually closed in order to prevent program from
 	// freezing on `done` channel in the `Output()` console's method.
 	plog.Infof("closing %s serial console SSH client", id)
-	if err := pm.console.CloseSSH(); err != nil {
-		plog.Errorf("closing serial console SSH client: %v", err)
+	if pm.console != nil {
+		if err := pm.console.CloseSSH(); err != nil {
+			plog.Errorf("closing serial console SSH client: %v", err)
+		}
 	}
 
 	if pm.journal != nil {


### PR DESCRIPTION
In case the test holds the flag `NoSSHKeyInMetadata`,
the console is not really created.

This is an issue when we destroy the machine since we try to
close the SSH console on a non-instantiated struct.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

Error has been raised in the CI:
```
--- FAIL: coreos.ignition.ssh.key (2013.61s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x16a4986]

goroutine 462 [running]:
github.com/flatcar-linux/mantle/harness.tRunner.func1(0xc00078d200)
	/usr/src/myapp/harness/harness.go:407 +0x26c
panic(0x204b700, 0x382b040)
	/usr/local/go/src/runtime/panic.go:965 +0x1b9
github.com/flatcar-linux/mantle/platform/machine/packet.(*console).CloseSSH(0x0, 0x3, 0x2597a45)
	/usr/src/myapp/platform/machine/packet/console.go:44 +0x26
github.com/flatcar-linux/mantle/platform/machine/packet.(*machine).Destroy(0xc001026a80)
	/usr/src/myapp/platform/machine/packet/machine.go:78 +0x185
github.com/flatcar-linux/mantle/platform.(*BaseCluster).Destroy(0xc001026080)
	/usr/src/myapp/platform/cluster.go:218 +0x6d
github.com/flatcar-linux/mantle/platform/machine/packet.(*cluster).Destroy(0xc000b3a340)
	/usr/src/myapp/platform/machine/packet/cluster.go:154 +0x2e
github.com/flatcar-linux/mantle/kola.runTest.func1(0xc00078d201, 0x28c2278, 0xc000b3a340, 0xc0004ca680, 0xc00078d200)
	/usr/src/myapp/kola/harness.go:501 +0x46f
github.com/flatcar-linux/mantle/kola.runTest(0xc00078d200, 0xc0004ca680, 0x7ffd9fb83d66, 0x6, 0x28bbaa0, 0xc0004475f0, 0x9abc66cfe201)
	/usr/src/myapp/kola/harness.go:566 +0x5ad
github.com/flatcar-linux/mantle/kola.RunTests.func1(0xc00078d200)
	/usr/src/myapp/kola/harness.go:390 +0x65
github.com/flatcar-linux/mantle/harness.tRunner(0xc00078d200, 0xc0001cd2c0)
	/usr/src/myapp/harness/harness.go:441 +0x104
created by github.com/flatcar-linux/mantle/harness.(*H).Run
	/usr/src/myapp/harness/harness.go:479 +0x327
Finished with result: exit-code
```

## Testing done

```
sudo ./bin/kola run ... coreos.ignition.ssh.key
```
