### PR TITLE
Azure gallery image support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - BPF execsnoop test ([#233](https://github.com/flatcar-linux/mantle/pull/233))
 - plume: Enable arm64 board uploads for the Stable channel ([#266](https://github.com/flatcar-linux/mantle/pull/266))
 - A way to reuse Equinix Metal devices during tests ([#268](https://github.com/flatcar-linux/mantle/pull/268))
+- plume: Enable arm64 board uploads for Azure ([#270](https://github.com/flatcar-linux/mantle/pull/270))
+- kola: Support for using gallery images on Azure ([#270](https://github.com/flatcar-linux/mantle/pull/270))
 
 ### Changed
 - `lsblk --json` output handling ([#244](https://github.com/flatcar-linux/mantle/pull/244))

--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -107,6 +107,7 @@ func init() {
 	sv(&kola.AzureOptions.Location, "azure-location", "westus", "Azure location (default \"westus\"")
 	sv(&kola.AzureOptions.Size, "azure-size", "Standard_DS2_v2", "Azure machine size (default \"Standard_DS2_v2\")")
 	sv(&kola.AzureOptions.HyperVGeneration, "azure-hyper-v-generation", "V1", "Azure Hyper-V Generation (\"V1\" or \"V2\")")
+	bv(&kola.AzureOptions.UseGallery, "azure-use-gallery", false, "Use gallery image instead of managed image")
 
 	// do-specific options
 	sv(&kola.DOOptions.ConfigPath, "do-config-file", "", "DigitalOcean config file (default \"~/"+auth.DOConfigPath+"\")")

--- a/cmd/plume/containerlinux.go
+++ b/cmd/plume/containerlinux.go
@@ -33,7 +33,7 @@ var (
 	specAwsPartition  string
 	specPrivateBucket bool
 	gceBoards         = []string{"amd64-usr", "arm64-usr"}
-	azureBoards       = []string{"amd64-usr"}
+	azureBoards       = []string{"amd64-usr", "arm64-usr"}
 	awsBoards         = []string{"amd64-usr", "arm64-usr"}
 	azureEnvironments = []azureEnvironmentSpec{
 		azureEnvironmentSpec{

--- a/platform/api/azure/api.go
+++ b/platform/api/azure/api.go
@@ -42,6 +42,7 @@ var (
 type API struct {
 	client     management.Client
 	rgClient   resources.GroupsClient
+	depClient  resources.DeploymentsClient
 	imgClient  compute.ImagesClient
 	compClient compute.VirtualMachinesClient
 	netClient  network.VirtualNetworksClient
@@ -143,6 +144,9 @@ func (a *API) SetupClients() error {
 	a.rgClient = resources.NewGroupsClient(settings.GetSubscriptionID())
 	a.rgClient.Authorizer = auther
 
+	a.depClient = resources.NewDeploymentsClient(settings.GetSubscriptionID())
+	a.depClient.Authorizer = auther
+
 	auther, err = auth.NewAuthorizerFromFile(compute.DefaultBaseURI)
 	if err != nil {
 		return err
@@ -175,10 +179,13 @@ func (a *API) SetupClients() error {
 	return nil
 }
 
-func randomName(prefix string) string {
+func randomNameEx(prefix, separator string) string {
 	b := make([]byte, 5)
 	rand.Read(b)
-	return fmt.Sprintf("%s-%x", prefix, b)
+	return fmt.Sprintf("%s%s%x", prefix, separator, b)
+}
+func randomName(prefix string) string {
+	return randomNameEx(prefix, "-")
 }
 
 func (a *API) GetOpts() *Options {

--- a/platform/api/azure/gallery-image-template.json
+++ b/platform/api/azure/gallery-image-template.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "galleries_name": {
+      "type": "string",
+      "defaultValue": "kolaSIG"
+    },
+    "image_name": {
+      "type": "string",
+      "defaultValue": "Flatcar"
+    },
+    "image_version": {
+      "type": "string",
+      "defaultValue": "1.0.0"
+    },
+    "storageAccounts_name": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "vhd_uri": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]"
+    },
+    "hyperVGeneration": {
+      "type": "string",
+      "defaultValue": "V2",
+      "allowedValues": [
+        "V1",
+        "V2"
+      ]
+    },
+    "architecture": {
+      "type": "string",
+      "defaultValue": "x64",
+      "allowedValues": [
+        "x64",
+        "Arm64"
+      ]
+    }
+  },
+  "resources": [
+    {
+      "apiVersion": "2021-07-01",
+      "location": "[parameters('location')]",
+      "name": "[parameters('galleries_name')]",
+      "properties": {
+        "identifier": {}
+      },
+      "type": "Microsoft.Compute/galleries"
+    },
+    {
+      "apiVersion": "2021-07-01",
+      "dependsOn": [
+        "[resourceId('Microsoft.Compute/galleries', parameters('galleries_name'))]"
+      ],
+      "location": "[parameters('location')]",
+      "name": "[concat(parameters('galleries_name'), '/', parameters('image_name'))]",
+      "properties": {
+        "hyperVGeneration": "[parameters('hyperVGeneration')]",
+        "architecture": "[parameters('architecture')]",
+        "identifier": {
+          "offer": "Flatcar",
+          "publisher": "kola",
+          "sku": "dev"
+        },
+        "osState": "Generalized",
+        "osType": "Linux",
+        "recommended": {
+          "memory": {
+            "max": 32,
+            "min": 1
+          },
+          "vCPUs": {
+            "max": 16,
+            "min": 1
+          }
+        }
+      },
+      "type": "Microsoft.Compute/galleries/images"
+    },
+    {
+      "apiVersion": "2021-07-01",
+      "dependsOn": [
+        "[resourceId('Microsoft.Compute/galleries/images', parameters('galleries_name'), parameters('image_name'))]",
+        "[resourceId('Microsoft.Compute/galleries', parameters('galleries_name'))]"
+      ],
+      "location": "[parameters('location')]",
+      "name": "[concat(parameters('galleries_name'), '/', parameters('image_name'), '/', parameters('image_version'))]",
+      "properties": {
+        "publishingProfile": {
+          "excludeFromLatest": false,
+          "replicaCount": 1,
+          "replicationMode": "Shallow",
+          "storageAccountType": "Standard_LRS",
+          "targetRegions": [
+            {
+              "name": "[parameters('location')]",
+              "regionalReplicaCount": 1,
+              "storageAccountType": "Standard_LRS"
+            }
+          ]
+        },
+        "storageProfile": {
+          "osDiskImage": {
+            "hostCaching": "ReadOnly",
+            "source": {
+              "id": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_name'))]",
+              "uri": "[parameters('vhd_uri')]"
+            }
+          }
+        }
+      },
+      "type": "Microsoft.Compute/galleries/images/versions"
+    }
+  ],
+  "variables": {}
+}

--- a/platform/api/azure/image.go
+++ b/platform/api/azure/image.go
@@ -17,6 +17,8 @@ package azure
 import (
 	"bufio"
 	"context"
+	_ "embed"
+	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	"net/http"
@@ -24,6 +26,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/classic/management"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-03-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2020-10-01/resources"
 )
 
 // OSImage struct for https://msdn.microsoft.com/en-us/library/azure/jj157192.aspx call.
@@ -72,6 +75,83 @@ func IsConflictError(err error) bool {
 	return ok && azerr.Code == "ConflictError"
 }
 
+//go:embed gallery-image-template.json
+var galleryImageTemplate []byte
+
+const (
+	deploymentName    = "kolagalleryimage"
+	galleryNamePrefix = "kolaSIG"
+	imageVersion      = "0.0.0"
+)
+
+type paramValue struct {
+	Value string `json:"value"`
+}
+type galleryParams struct {
+	GalleriesName       paramValue `json:"galleries_name"`
+	ImageName           paramValue `json:"image_name"`
+	ImageVersion        paramValue `json:"image_version"`
+	StorageAccountsName paramValue `json:"storageAccounts_name"`
+	VhdUri              paramValue `json:"vhd_uri"`
+	Location            paramValue `json:"location"`
+	Architecture        paramValue `json:"architecture"`
+	HyperVGeneration    paramValue `json:"hyperVGeneration"`
+}
+
+
+// CreateGalleryImage creates an Azure Compute Gallery with 1 image version referencing the blob as the disk
+func (a *API) CreateGalleryImage(name, resourceGroup, storageAccount, blobURI string) (string, error) {
+	plog.Infof("Creating Gallery Image %s", name)
+	galleryName := randomNameEx(galleryNamePrefix, "")
+	template := make(map[string]interface{})
+	err := json.Unmarshal(galleryImageTemplate, &template)
+	if err != nil {
+		return "", fmt.Errorf("failed to unmarshal gallery template: %w", err)
+	}
+	galleryParams := galleryParams{
+		GalleriesName:       paramValue{galleryName},
+		ImageName:           paramValue{name},
+		ImageVersion:        paramValue{imageVersion},
+		StorageAccountsName: paramValue{storageAccount},
+		VhdUri:              paramValue{blobURI},
+		Location:            paramValue{a.opts.Location},
+		Architecture:        paramValue{"x64"},
+		HyperVGeneration:    paramValue{a.opts.HyperVGeneration},
+	}
+	params := make(map[string]interface{})
+	paramsData, err := json.Marshal(&galleryParams)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal gallery params: %w", err)
+	}
+	err = json.Unmarshal(paramsData, &params)
+	if err != nil {
+		return "", fmt.Errorf("failed to unmarshal gallery params: %w", err)
+	}
+
+	future, err := a.depClient.CreateOrUpdate(context.TODO(),
+		resourceGroup,
+		deploymentName,
+		resources.Deployment{
+			Properties: &resources.DeploymentProperties{
+				Template:   template,
+				Parameters: params,
+				Mode:       resources.DeploymentModeIncremental,
+			},
+		},
+	)
+	if err != nil {
+		return "", err
+	}
+	err = future.WaitForCompletionRef(context.TODO(), a.depClient.Client)
+	if err != nil {
+		return "", err
+	}
+	id := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/galleries/%s/images/%s/versions/%s",
+		a.opts.SubscriptionID, resourceGroup, galleryName, name, imageVersion)
+	return id, nil
+}
+
+// CreateImage creates a managed image referencing the blob as the disk
 func (a *API) CreateImage(name, resourceGroup, blobURI string) (compute.Image, error) {
 	plog.Infof("Creating Image %s", name)
 	future, err := a.imgClient.CreateOrUpdate(context.TODO(), resourceGroup, name, compute.Image{

--- a/platform/api/azure/image.go
+++ b/platform/api/azure/image.go
@@ -98,6 +98,15 @@ type galleryParams struct {
 	HyperVGeneration    paramValue `json:"hyperVGeneration"`
 }
 
+func azureArchForBoard(board string) string {
+	switch board {
+	case "amd64-usr":
+		return "x64"
+	case "arm64-usr":
+		return "Arm64"
+	}
+	return ""
+}
 
 // CreateGalleryImage creates an Azure Compute Gallery with 1 image version referencing the blob as the disk
 func (a *API) CreateGalleryImage(name, resourceGroup, storageAccount, blobURI string) (string, error) {
@@ -115,7 +124,7 @@ func (a *API) CreateGalleryImage(name, resourceGroup, storageAccount, blobURI st
 		StorageAccountsName: paramValue{storageAccount},
 		VhdUri:              paramValue{blobURI},
 		Location:            paramValue{a.opts.Location},
-		Architecture:        paramValue{"x64"},
+		Architecture:        paramValue{azureArchForBoard(a.opts.Board)},
 		HyperVGeneration:    paramValue{a.opts.HyperVGeneration},
 	}
 	params := make(map[string]interface{})

--- a/platform/api/azure/options.go
+++ b/platform/api/azure/options.go
@@ -35,6 +35,7 @@ type Options struct {
 	Size             string
 	Location         string
 	HyperVGeneration string
+	UseGallery       bool
 
 	SubscriptionName string
 	SubscriptionID   string


### PR DESCRIPTION
# Azure gallery image support

This PR adds support for using gallery images on Azure. For now this is in kola only, to be used for testing. In a later step we could then move our publishing process to gallery images, which will reduce the possibility of errors when publishing on the marketplace. This would not simplify automation because the marketplace APIs only support VHD urls.

## How to use

```
./bin/kola spawn --azure-auth ~/.azure/azureCredentials.json --azure-blob-url "..." --platform azure --verbose --azure-use-gallery
```

## Testing done

Ran `kola spawn` successfully.

- [X] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
