### PR TITLE
plume: bugfixes for release steps

### DIFF
--- a/cmd/plume/containerlinux.go
+++ b/cmd/plume/containerlinux.go
@@ -227,6 +227,17 @@ func AmiNameArchTag() string {
 	}
 }
 
+func AzureBlobName() string {
+	archTag := ""
+	switch specBoard {
+	case "amd64-usr":
+		archTag = "amd64"
+	case "arm64-usr":
+		archTag = "arm64"
+	}
+	return fmt.Sprintf("flatcar-linux-%s-%s-%s.vhd", specVersion, specChannel, archTag)
+}
+
 func ChannelSpec() channelSpec {
 	if specBoard == "" {
 		plog.Fatal("--board is required")

--- a/cmd/plume/prerelease.go
+++ b/cmd/plume/prerelease.go
@@ -270,7 +270,7 @@ type azureImageInfo struct {
 func azurePreRelease(ctx context.Context, client *http.Client, src *storage.Bucket, spec *channelSpec, imageInfo *imageInfo) error {
 
 	specAzure := spec.Azure
-	blobName := fmt.Sprintf("flatcar-linux-%s-%s.vhd", specVersion, specChannel)
+	blobName := AzureBlobName()
 
 	if azureCategory == "pro" {
 		specAzure = spec.AzurePremium

--- a/cmd/plume/release.go
+++ b/cmd/plume/release.go
@@ -387,6 +387,14 @@ func doAzure(ctx context.Context, client *http.Client, src *storage.Bucket, spec
 
 		var url string
 		for _, key := range *storageKey.Keys {
+			blobExists, err := api.BlobExists(spec.Azure.StorageAccount, *key.Value, container, blobName)
+			if err != nil {
+				continue
+			}
+			if !blobExists {
+				plog.Notice("Blob does not exist, skipping.")
+				return
+			}
 			url, err = api.SignBlob(spec.Azure.StorageAccount, *key.Value, container, blobName)
 			if err == nil {
 				break

--- a/cmd/plume/release.go
+++ b/cmd/plume/release.go
@@ -353,7 +353,7 @@ func doAzure(ctx context.Context, client *http.Client, src *storage.Bucket, spec
 		return
 	}
 
-	blobName := fmt.Sprintf("flatcar-linux-%s-%s.vhd", specVersion, specChannel)
+	blobName := AzureBlobName()
 
 	for _, environment := range spec.Azure.Environments {
 		api, err := azure.New(&azure.Options{


### PR DESCRIPTION
# plume: bugfixes for release steps

These are bugfixes for two issues that popped up after `azureBoards` was extended in #270.
1. `plume release` needs to check that the release of a channel is intended. Do this by checking for the blob existing.
2. `plume prerelease` used a blob path that did not contain the board name, collisions were possible. The name now includes the board name.

I opted for adding board to the blob name instead of doing "virtual" directories, because that way copying the blob to a machine/different directory will preserve this information.

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
