### PR TITLE
ore: prevent reusing the amd64 EBS snapshot

### DIFF
--- a/cmd/ore/aws/upload.go
+++ b/cmd/ore/aws/upload.go
@@ -148,6 +148,10 @@ func runUpload(cmd *cobra.Command, args []string) error {
 			os.Exit(1)
 		}
 		imageName = ver.Version
+		// Follow plume's AmiNameArchTag convention by only having a suffix for the arm64 image
+		if uploadBoard == "arm64-usr" {
+			imageName += "-arm64"
+		}
 	}
 
 	if uploadDiskSizeInspect {


### PR DESCRIPTION
The ore image name was defaulting to the version in contrast to plume
where we assemble a more complete name. This led to a reuse of the
amd64 EBS snapshot for arm64, or vice versa.

Add an arch suffix as done in plume (i.e., only for arm64 to keep the
existing name for amd64).


## How to use


## Testing done

None

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
