### PR TITLE
Revert "kola/test/kubeadm: exclude `kubeadm.calico` from `arm64` tests"

### DIFF
--- a/kola/tests/kubeadm/kubeadm.go
+++ b/kola/tests/kubeadm/kubeadm.go
@@ -132,12 +132,6 @@ func init() {
 			testParams["CNI"] = CNI
 			testParams["Release"] = version
 
-			architectures := []string{"amd64"}
-
-			if CNI != "calico" {
-				architectures = append(architectures, "arm64")
-			}
-
 			register.Register(&register.Test{
 				Name:             fmt.Sprintf("kubeadm.%s.%s.base", version, CNI),
 				Distros:          []string{"cl"},
@@ -145,7 +139,6 @@ func init() {
 				Run: func(c cluster.TestCluster) {
 					kubeadmBaseTest(c, testParams)
 				},
-				Architectures: architectures,
 			})
 		}
 	}


### PR DESCRIPTION
This reverts commit 222dbf31a8c332c505a65ac51548c2750e8b3250.

`calico` for ARM64 seems to be OK now, let's pull in into Kola :)

## Testing done

```bash
./build kola
sudo ./bin/kola run --board=arm64-usr --platform=packet ... kubeadm.v1.23.0.calico.base
...
    --- PASS: kubeadm.v1.23.0.calico.base/node_readiness (25.53s)
    --- PASS: kubeadm.v1.23.0.calico.base/nginx_deployment (16.14s)
```

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
