### PR TITLE
kola: Ignore dead links in /run/udev/links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - removed `packet` occurrences in favor of `equinixmetal` ([#277](https://github.com/flatcar-linux/mantle/pull/277))
+- kola: fixed cl.filesystem test for systemd 250 and newer ([#280](https://github.com/flatcar-linux/mantle/pull/280))
 
 ## [0.18.0] - 12/01/2022
 ### Security

--- a/kola/tests/misc/files.go
+++ b/kola/tests/misc/files.go
@@ -77,6 +77,7 @@ func DeadLinks(c cluster.TestCluster) {
 		"/dev",
 		"/proc",
 		"/run/systemd",
+		"/run/udev/links",
 		"/run/udev/watch",
 		"/sys",
 		"/var/lib/docker",


### PR DESCRIPTION
Previously the entries in the directory were like `rtc/c252:0`, where
`c252:0` was just an empty file. Starting from systemd 250 it became a
dead symlink which points to `-100:/dev/rtc0`. This has caused the
`cl.filesystem` test to fail. To fix it, we add another entry to the
ignore list.

Should fix an issue like follows:

```
  Error: "--- FAIL: cl.filesystem/deadlinks (0.42s)
            files.go:89: Dead symbolic links found: [
/run/udev/links/disk\\x2fby-id\\x2fata-QEMU_DVD-ROM_QM00003/b11:0
/run/udev/links/disk\\x2fby-path\\x2fpci-0000:00:01.1-ata-2.0/b11:0
/run/udev/links/disk\\x2fby-path\\x2fpci-0000:00:01.1-ata-2/b11:0
…
yadda yadda yadda
]"
```

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
