### PR TITLE
cmd/cork,sdk: remove --repo-branch option from cork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - removed `packet` occurrences in favor of `equinixmetal` ([#277](https://github.com/flatcar-linux/mantle/pull/277))
 - kola: fixed cl.filesystem test for systemd 250 and newer ([#280](https://github.com/flatcar-linux/mantle/pull/280))
 
+### Removed
+- Remove `--repo-branch` option from cork ([#283](https://github.com/flatcar-linux/mantle/pull/283))
+
 ## [0.18.0] - 12/01/2022
 ### Security
 - go: Update golang.org/x/{text,crypto} ([#262](https://github.com/flatcar-linux/mantle/pull/262))

--- a/cmd/cork/create.go
+++ b/cmd/cork/create.go
@@ -29,16 +29,6 @@ import (
 
 const (
 	coreosManifestURL = "https://github.com/kinvolk/manifest.git"
-	// Set repoUpstreamBranch to "maint", until the upstream repo >= v2.10
-	// could be available in ordinary SDK environments. That is to avoid
-	// incompatibility issue of an old repo tool not being able to work with
-	// the default "stable" branch of the repo tool,
-	// https://gerrit.googlesource.com/git-repo/+/refs/heads/stable,
-	// which does not support python2 any more. OTOH its "maint" branch still
-	// supports python2. In the long term, we should update "dev-vcs/repo"
-	// in Flatcar SDK to v2.10 with python3, and set the default branch back
-	// to "stable".
-	repoUpstreamBranch = "maint"
 )
 
 var (
@@ -55,7 +45,6 @@ var (
 	manifestURL    string
 	manifestName   string
 	manifestBranch string
-	repoBranch     string
 	repoVerify     bool
 	sigVerify      bool
 
@@ -135,8 +124,6 @@ func init() {
 		"manifest-branch", "flatcar-master", "Manifest git repo branch")
 	creationFlags.StringVar(&manifestName,
 		"manifest-name", "default.xml", "Manifest file name")
-	creationFlags.StringVar(&repoBranch,
-		"repo-branch", repoUpstreamBranch, "Branch name to be used from the upstream git repo of repo tool")
 	creationFlags.BoolVar(&repoVerify,
 		"verify", false, "Check repo tree and release manifest match")
 	creationFlags.StringVar(&downloadImageJSONKeyFile,
@@ -279,7 +266,7 @@ func unpackChroot(replace bool) {
 }
 
 func updateRepo() {
-	if err := sdk.RepoInit(chrootName, manifestURL, manifestBranch, manifestName, repoBranch, useHostDNS); err != nil {
+	if err := sdk.RepoInit(chrootName, manifestURL, manifestBranch, manifestName, useHostDNS); err != nil {
 		plog.Fatalf("repo init failed: %v", err)
 	}
 

--- a/sdk/repo.go
+++ b/sdk/repo.go
@@ -129,7 +129,7 @@ func BuildImageDir(board, version string) string {
 	return filepath.Join(BuildRoot(), "images", board, dir)
 }
 
-func RepoInit(chroot, url, manifestBranch, name, repoBranch string, useHostDNS bool) error {
+func RepoInit(chroot, url, manifestBranch, name string, useHostDNS bool) error {
 	return enterChroot(enter{
 		Chroot:     chroot,
 		CmdDir:     chrootRepoRoot,
@@ -139,7 +139,6 @@ func RepoInit(chroot, url, manifestBranch, name, repoBranch string, useHostDNS b
 			"--manifest-url", url,
 			"--manifest-branch", manifestBranch,
 			"--manifest-name", name,
-			"--repo-branch", repoBranch,
 		}})
 }
 


### PR DESCRIPTION
Now that repo 2.8 is available in all Flatcar channels, the option `--repo-branch` is not needed any more.
Delete the option, and simply use the `master` branch of the git repo.

This reverts commit 071390132fb5285f907a80424f5bd806c4d90fd0.

## Testing done

local build passed

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
