### PR TITLE
kola/test/ignition/fs: add swap_activation test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - arm64 kubeadm test for `calico` CNI ([#278](https://github.com/flatcar-linux/mantle/pull/278))
 - `Metro` to Equinix Metal options ([#281](https://github.com/flatcar-linux/mantle/pull/281))
 - `update-offer` ore subcommand for AWS marketplace publishing ([#282](https://github.com/flatcar-linux/mantle/pull/282))
+- kola test `cl.swap_activation` for swap activation with CLC ([#284](https://github.com/flatcar-linux/mantle/pull/284))
 
 ### Changed
 - removed `packet` occurrences in favor of `equinixmetal` ([#277](https://github.com/flatcar-linux/mantle/pull/277))


### PR DESCRIPTION
This test aims to reproduce swap activation behavior on FCL through CLC

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

Related to:
* https://github.com/flatcar-linux/Flatcar/issues/133
* https://www.flatcar.org/docs/latest/setup/storage/adding-swap/#adding-swap-with-a-container-linux-config

## Testing done

Tested locally with Stable-3033.2.1 and Alpha-3127.0.0


- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
