### PR TITLE
kola/test/ignition/fs: break dependencies cycle

### DIFF
--- a/kola/tests/ignition/filesystem.go
+++ b/kola/tests/ignition/filesystem.go
@@ -286,7 +286,6 @@ systemd:
         [Unit]
         Description=Create a swapfile
         RequiresMountsFor=/var
-        ConditionPathExists=!%[1]s
 
         [Service]
         Type=oneshot

--- a/kola/tests/ignition/filesystem.go
+++ b/kola/tests/ignition/filesystem.go
@@ -286,6 +286,7 @@ systemd:
         [Unit]
         Description=Create a swapfile
         RequiresMountsFor=/var
+        DefaultDependencies=no
 
         [Service]
         Type=oneshot


### PR DESCRIPTION
Service units as default dependencies to `sysinit.target`, this can create a cycle since `create-swap.service` is required by `var-vm-swapfile1.swap` and this is required by `swap.target` which is required by `sysinit.target`.

<hr>

- No changelog required