### PR TITLE
platform/api/aws: use env credentials when no other creds are provided

### DIFF
--- a/platform/api/aws/api.go
+++ b/platform/api/aws/api.go
@@ -78,6 +78,8 @@ func New(opts *Options) (*API, error) {
 		awsCfg.Credentials = credentials.NewStaticCredentials(opts.AccessKeyID, opts.SecretKey, "")
 	} else if opts.CredentialsFile != "" {
 		awsCfg.Credentials = credentials.NewSharedCredentials(opts.CredentialsFile, opts.Profile)
+	} else {
+		awsCfg.Credentials = credentials.NewEnvCredentials()
 	}
 
 	sess, err := session.NewSessionWithOptions(session.Options{


### PR DESCRIPTION
We updated the AWS SDK and hit by a change which caused environment
credentials to be ignored when a profile is passed. Details are here[1]
Explicily set credentials to NewEnvCredentials() to make this work
again. Without this, tests fail in kola:

  2022-02-04T01:19:43Z kola: creating flight for RunTests failed: NoCredentialProviders: no valid providers in chain. Deprecated.
	For verbose messaging see aws.Config.CredentialsChainVerboseErrors

[1]: https://github.com/aws/aws-sdk-go/issues/3382