### PR TITLE
platform/qemu: use -readonly=on

### DIFF
--- a/platform/qemu.go
+++ b/platform/qemu.go
@@ -304,7 +304,7 @@ func CreateQEMUCommand(board, uuid, biosImage, consolePath, confPath, diskImageP
 			"-fw_cfg", "name=opt/org.flatcar-linux/config,file="+confPath)
 	} else {
 		qmCmd = append(qmCmd,
-			"-fsdev", "local,id=cfg,security_model=none,readonly,path="+confPath,
+			"-fsdev", "local,id=cfg,security_model=none,readonly=on,path="+confPath,
 			"-device", Virtio(board, "9p", "fsdev=cfg,mount_tag=config-2"))
 	}
 


### PR DESCRIPTION
shortforms are deprecated from qemu-6.0.0. For tests with cloudinit config
we were getting the following warning:
```
=== RUN   cl.cloudinit.basic
qemu-system-x86_64: -fsdev local,id=cfg,security_model=none,readonly,path=_kola_temp/qemu-2022-02-10-1010-4882/cl.cloudinit.basic/65f5b234-64a4-4154-b1d9-d5168056f5e5/config-2: warning: short-form boolean option 'readonly' deprecated
Please use readonly=on instead
--- PASS: cl.cloudinit.basic (20.49s)
```

Similar to: https://github.com/flatcar-linux/scripts/pull/132

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

No changelog required.