### PR TITLE
improve aws test runtime and logging

### DIFF
--- a/platform/api/aws/ec2.go
+++ b/platform/api/aws/ec2.go
@@ -262,6 +262,7 @@ func (a *API) CreateTags(resources []string, tags map[string]string) error {
 func (a *API) GetConsoleOutput(instanceID string) (string, error) {
 	res, err := a.ec2.GetConsoleOutput(&ec2.GetConsoleOutputInput{
 		InstanceId: aws.String(instanceID),
+		Latest:     util.BoolToPtr(true),
 	})
 	if err != nil {
 		return "", fmt.Errorf("couldn't get console output of %v: %v", instanceID, err)

--- a/platform/api/aws/ec2.go
+++ b/platform/api/aws/ec2.go
@@ -224,10 +224,18 @@ func (a *API) TerminateInstances(ids []string) error {
 	if len(ids) == 0 {
 		return nil
 	}
+
+	stopInput := &ec2.StopInstancesInput{
+		InstanceIds: aws.StringSlice(ids),
+		Force:       util.BoolToPtr(true),
+	}
+	if _, err := a.ec2.StopInstances(stopInput); err != nil {
+		return err
+	}
+
 	input := &ec2.TerminateInstancesInput{
 		InstanceIds: aws.StringSlice(ids),
 	}
-
 	if _, err := a.ec2.TerminateInstances(input); err != nil {
 		return err
 	}

--- a/platform/machine/aws/machine.go
+++ b/platform/machine/aws/machine.go
@@ -98,7 +98,7 @@ func (am *machine) saveConsole(origConsole string) error {
 	// returned output will be non-empty but won't necessarily include
 	// the most recent log messages. So we loop until the post-termination
 	// logs are different from the pre-termination logs.
-	err := util.WaitUntilReady(5*time.Minute, 5*time.Second, func() (bool, error) {
+	err := util.WaitUntilReady(30*time.Second, 10*time.Second, func() (bool, error) {
 		var err error
 		am.console, err = am.cluster.flight.api.GetConsoleOutput(am.ID())
 		if err != nil {

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	sshRetries = 120
+	sshRetries = 60
 	sshTimeout = 10 * time.Second
 )
 


### PR DESCRIPTION
# improve aws test speed and logging

Several improvements to the test runtime and logging:
* instances are force stopped before terminating
* we fetch "latest" console output, which is supported on Nitro. Without the "latest" option, console output is only updated on instance lifecycle events
* reduce the timeout for new console data - the 300s timeout for updated console output  stalls almost every test case on AWS. 30s wait should be enough
* rework retry handling when establishing a journalctl connection: 120 retries, 10s delay between retries, and the ssh timeout itself meant that some failing test cases spent 6000s (!!!) before timing out. Rework with to 60 retries with a bounded timeout of 600s.

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
