### PR TITLE
kubeadm/cilium: bump tested versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - removed `packet` occurrences in favor of `equinixmetal` ([#277](https://github.com/flatcar-linux/mantle/pull/277))
 - kola: fixed cl.filesystem test for systemd 250 and newer ([#280](https://github.com/flatcar-linux/mantle/pull/280))
 - PXE boots now over HTTPS on Equinix Metal ([#288](https://github.com/flatcar-linux/mantle/pull/288))
+- Bumped cilium tested version to 1.11.0 ([291](https://github.com/flatcar-linux/mantle/pull/291))
 
 ### Removed
 - Remove `--repo-branch` option from cork ([#283](https://github.com/flatcar-linux/mantle/pull/283))

--- a/kola/tests/kubeadm/kubeadm.go
+++ b/kola/tests/kubeadm/kubeadm.go
@@ -45,6 +45,7 @@ var (
 	testConfig = map[string]map[string]interface{}{
 		"v1.23.0": map[string]interface{}{
 			"FlannelVersion":   "v0.14.0",
+			"CiliumVersion":    "1.11.0",
 			"CiliumCLIVersion": "v0.10.2",
 			"CNIVersion":       "v0.8.7",
 			"CRIctlVersion":    "v1.22.0",
@@ -68,6 +69,7 @@ var (
 		},
 		"v1.22.0": map[string]interface{}{
 			"FlannelVersion":   "v0.14.0",
+			"CiliumVersion":    "1.11.0",
 			"CiliumCLIVersion": "v0.10.2",
 			"CNIVersion":       "v0.8.7",
 			"CRIctlVersion":    "v1.17.0",
@@ -91,6 +93,7 @@ var (
 		},
 		"v1.21.0": map[string]interface{}{
 			"FlannelVersion":   "v0.14.0",
+			"CiliumVersion":    "1.11.0",
 			"CiliumCLIVersion": "v0.10.2",
 			"CNIVersion":       "v0.8.7",
 			"CRIctlVersion":    "v1.17.0",

--- a/kola/tests/kubeadm/kubeadm.go
+++ b/kola/tests/kubeadm/kubeadm.go
@@ -45,7 +45,7 @@ var (
 	testConfig = map[string]map[string]interface{}{
 		"v1.23.0": map[string]interface{}{
 			"FlannelVersion":   "v0.14.0",
-			"CiliumCLIVersion": "v0.9.0",
+			"CiliumCLIVersion": "v0.10.2",
 			"CNIVersion":       "v0.8.7",
 			"CRIctlVersion":    "v1.22.0",
 			"ReleaseVersion":   "v0.4.0",
@@ -68,7 +68,7 @@ var (
 		},
 		"v1.22.0": map[string]interface{}{
 			"FlannelVersion":   "v0.14.0",
-			"CiliumCLIVersion": "v0.9.0",
+			"CiliumCLIVersion": "v0.10.2",
 			"CNIVersion":       "v0.8.7",
 			"CRIctlVersion":    "v1.17.0",
 			"ReleaseVersion":   "v0.4.0",
@@ -91,7 +91,7 @@ var (
 		},
 		"v1.21.0": map[string]interface{}{
 			"FlannelVersion":   "v0.14.0",
-			"CiliumCLIVersion": "v0.9.0",
+			"CiliumCLIVersion": "v0.10.2",
 			"CNIVersion":       "v0.8.7",
 			"CRIctlVersion":    "v1.17.0",
 			"ReleaseVersion":   "v0.4.0",

--- a/kola/tests/kubeadm/kubeadm_test.go
+++ b/kola/tests/kubeadm/kubeadm_test.go
@@ -54,6 +54,7 @@ func TestRenderTemplate(t *testing.T) {
 			res, err := render(
 				masterScript,
 				map[string]interface{}{
+					"CiliumVersion":  "v0.11.1",
 					"FlannelVersion": "v0.14.0",
 					"CNI":            CNI,
 					"Endpoints":      []string{"http://1.2.3.4:2379"},
@@ -83,6 +84,7 @@ func TestRenderTemplate(t *testing.T) {
 			res, err := render(
 				masterConfig,
 				map[string]interface{}{
+					"CiliumVersion":    "v0.11.1",
 					"CNI":              "cilium",
 					"CiliumCLIVersion": "v0.9.0",
 					"Endpoints":        []string{"http://1.2.3.4:2379"},

--- a/kola/tests/kubeadm/templates.go
+++ b/kola/tests/kubeadm/templates.go
@@ -361,7 +361,8 @@ EOF
     sudo tar -xf {{ .DownloadDir }}/cilium.tar.gz -C {{ .DownloadDir }}
     /opt/bin/cilium install \
         --config enable-endpoint-routes=true \
-        --config cluster-pool-ipv4-cidr={{ .PodSubnet }}
+        --config cluster-pool-ipv4-cidr={{ .PodSubnet }} \
+        --version={{ .CiliumVersion }}
     # --wait will wait for status to report success
     /opt/bin/cilium status --wait
 {{ end }}

--- a/kola/tests/kubeadm/testdata/master-cilium-script.sh
+++ b/kola/tests/kubeadm/testdata/master-cilium-script.sh
@@ -88,7 +88,8 @@ EOF
     sudo tar -xf /opt/bin/cilium.tar.gz -C /opt/bin
     /opt/bin/cilium install \
         --config enable-endpoint-routes=true \
-        --config cluster-pool-ipv4-cidr=192.168.0.0/17
+        --config cluster-pool-ipv4-cidr=192.168.0.0/17 \
+        --version=v0.11.1
     # --wait will wait for status to report success
     /opt/bin/cilium status --wait
 


### PR DESCRIPTION
In this PR, we bump the cilium version to latest v1.11.0 and we give the ability to set the version from the `cilium-cli` directly, since it has been introduced in the CLI. 

This PR aims to have a more recent version of the tested cilium in order to prepare the introduction of a new test to validate the behavior of IPSec + cilium.

## Testing done

* tests on EM with `kubeadm.v1.23.0.cilium.base`

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
