### PR TITLE
kubeadm: extend CNI tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added simple wireguard test ([#348](https://github.com/flatcar-linux/mantle/pull/348))
 - Added SSH proxy jump to Openstack platform ([#349](https://github.com/flatcar-linux/mantle/pull/349))
 - Added URL support for Openstack image creation ([#350](https://github.com/flatcar-linux/mantle/pull/350))
+- kola tests for Cilium IPSec encryption ([#292](https://github.com/flatcar-linux/mantle/pull/292))
 
 ### Changed
 - removed `packet` occurrences in favor of `equinixmetal` ([#277](https://github.com/flatcar-linux/mantle/pull/277))

--- a/kola/tests/kubeadm/kubeadm.go
+++ b/kola/tests/kubeadm/kubeadm.go
@@ -71,7 +71,7 @@ var (
 		},
 		"v1.23.4": map[string]interface{}{
 			"FlannelVersion":   "v0.16.3",
-			"CiliumVersion":    "1.11.0",
+			"CiliumVersion":    "1.11.2",
 			"CiliumCLIVersion": "v0.10.2",
 			"CNIVersion":       "v1.0.1",
 			"CRIctlVersion":    "v1.22.0",
@@ -96,7 +96,7 @@ var (
 		},
 		"v1.22.7": map[string]interface{}{
 			"FlannelVersion":   "v0.16.3",
-			"CiliumVersion":    "1.11.0",
+			"CiliumVersion":    "1.11.2",
 			"CiliumCLIVersion": "v0.10.2",
 			"CNIVersion":       "v1.0.1",
 			"CRIctlVersion":    "v1.22.0",

--- a/kola/tests/kubeadm/kubeadm.go
+++ b/kola/tests/kubeadm/kubeadm.go
@@ -46,7 +46,20 @@ type extraTest struct {
 
 var (
 	// extraTests can be used to extend the common tests for a given supported CNI.
-	extraTests = map[string][]extraTest{}
+	extraTests = map[string][]extraTest{
+		"cilium": []extraTest{
+			extraTest{
+				name: "IPSec encryption",
+				runFunc: func(controller platform.Machine, params map[string]interface{}, c cluster.TestCluster) {
+					_ = c.MustSSH(controller, "/opt/bin/cilium uninstall")
+					version := params["CiliumVersion"].(string)
+					cidr := params["PodSubnet"].(string)
+					cmd := fmt.Sprintf("/opt/bin/cilium install --config enable-endpoint-routes=true --config cluster-pool-ipv4-cidr=%s --version=%s --encryption=ipsec --wait --wait-duration 1m", cidr, version)
+					_ = c.MustSSH(controller, cmd)
+				},
+			},
+		},
+	}
 
 	// CNIs is the list of CNIs to deploy
 	// in the cluster setup


### PR DESCRIPTION
This PR is an attempt to extend kubeadm coverage by adding extra tests to test specific points for a CNI.

One test case has been added to cover the following use-case: https://github.com/flatcar-linux/Flatcar/issues/626 with IPSec encryption.

## Note for reviewers:
* the cluster is kept to avoid increasing overall time execution

## Testing done

* `kubeadm.v1.23.0.cilium.base`

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
