### PR TITLE
kola/tests/ignition/oem: inspect occasional test failure

### DIFF
--- a/kola/tests/ignition/oem.go
+++ b/kola/tests/ignition/oem.go
@@ -94,7 +94,8 @@ func reusePartition(c cluster.TestCluster) {
 	out := c.MustSSH(c.Machines()[0], `lsblk --output FSTYPE,LABEL,MOUNTPOINT --json | jq -r '.blockdevices | .[] | select(.label=="OEM") | .fstype'`)
 
 	if string(out) != "btrfs" {
-		c.Fatalf("should get btrfs, got: %s", string(out))
+		debug := c.MustSSH(c.Machines()[0], `lsblk --output FSTYPE,LABEL,MOUNTPOINT --json; echo ; lsblk`)
+		c.Fatalf("should get btrfs, got: %s\ndebug info: %s", string(out), string(debug))
 	}
 }
 


### PR DESCRIPTION
The cl.ignition.oem.regular test sometimes fails with
    "got: btrfs\nbtrfs".
    Print additional information to find the cause. 

## Testing done

[Here](http://jenkins.infra.kinvolk.io:8080/job/os/job/kola/job/qemu_uefi/6613/console) the test got executed without hitting the failure path:
```
--- PASS: cl.ignition.oem.regular (16.27s)
```
