### PR TITLE
azure private networking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `Metro` to Equinix Metal options ([#281](https://github.com/flatcar-linux/mantle/pull/281))
 - `update-offer` ore subcommand for AWS marketplace publishing ([#282](https://github.com/flatcar-linux/mantle/pull/282))
 - kola test `cl.swap_activation` for swap activation with CLC ([#284](https://github.com/flatcar-linux/mantle/pull/284))
+- Azure: support for running Kola within an existing vnet and with private addressing ([#295](https://github.com/flatcar-linux/mantle/pull/295))
 
 ### Changed
 - removed `packet` occurrences in favor of `equinixmetal` ([#277](https://github.com/flatcar-linux/mantle/pull/277))

--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -107,7 +107,9 @@ func init() {
 	sv(&kola.AzureOptions.Location, "azure-location", "westus", "Azure location (default \"westus\"")
 	sv(&kola.AzureOptions.Size, "azure-size", "Standard_DS2_v2", "Azure machine size (default \"Standard_DS2_v2\")")
 	sv(&kola.AzureOptions.HyperVGeneration, "azure-hyper-v-generation", "V1", "Azure Hyper-V Generation (\"V1\" or \"V2\")")
+	sv(&kola.AzureOptions.VnetSubnetName, "azure-vnet-subnet-name", "", "Use a pre-existing virtual network for created instances. Specify as vnet-name/subnet-name. Subnet name may be omitted \"default\" is assumed")
 	bv(&kola.AzureOptions.UseGallery, "azure-use-gallery", false, "Use gallery image instead of managed image")
+	bv(&kola.AzureOptions.UsePrivateIps, "azure-use-private-ips", false, "Assume nodes are reachable using private ip addresses")
 
 	// do-specific options
 	sv(&kola.DOOptions.ConfigPath, "do-config-file", "", "DigitalOcean config file (default \"~/"+auth.DOConfigPath+"\")")

--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -107,9 +107,9 @@ func init() {
 	sv(&kola.AzureOptions.Location, "azure-location", "westus", "Azure location (default \"westus\"")
 	sv(&kola.AzureOptions.Size, "azure-size", "Standard_DS2_v2", "Azure machine size (default \"Standard_DS2_v2\")")
 	sv(&kola.AzureOptions.HyperVGeneration, "azure-hyper-v-generation", "V1", "Azure Hyper-V Generation (\"V1\" or \"V2\")")
-	sv(&kola.AzureOptions.VnetSubnetName, "azure-vnet-subnet-name", "", "Use a pre-existing virtual network for created instances. Specify as vnet-name/subnet-name. Subnet name may be omitted \"default\" is assumed")
+	sv(&kola.AzureOptions.VnetSubnetName, "azure-vnet-subnet-name", "", "Use a pre-existing virtual network for created instances. Specify as vnet-name/subnet-name. If subnet name is omitted then \"default\" is assumed")
 	bv(&kola.AzureOptions.UseGallery, "azure-use-gallery", false, "Use gallery image instead of managed image")
-	bv(&kola.AzureOptions.UsePrivateIps, "azure-use-private-ips", false, "Assume nodes are reachable using private ip addresses")
+	bv(&kola.AzureOptions.UsePrivateIPs, "azure-use-private-ips", false, "Assume nodes are reachable using private IP addresses")
 
 	// do-specific options
 	sv(&kola.DOOptions.ConfigPath, "do-config-file", "", "DigitalOcean config file (default \"~/"+auth.DOConfigPath+"\")")

--- a/platform/api/azure/api.go
+++ b/platform/api/azure/api.go
@@ -53,6 +53,10 @@ type API struct {
 	opts       *Options
 }
 
+type Network struct {
+	subnet network.Subnet
+}
+
 // New creates a new Azure client. If no publish settings file is provided or
 // can't be parsed, an anonymous client is created.
 func New(opts *Options) (*API, error) {

--- a/platform/api/azure/instance.go
+++ b/platform/api/azure/instance.go
@@ -110,11 +110,8 @@ func (a *API) getVMParameters(name, userdata, sshkey, storageAccountURI string, 
 	}
 }
 
-func (a *API) CreateInstance(name, userdata, sshkey, resourceGroup, storageAccount string) (*Machine, error) {
-	subnet, err := a.getSubnet(resourceGroup)
-	if err != nil {
-		return nil, fmt.Errorf("preparing network resources: %v", err)
-	}
+func (a *API) CreateInstance(name, userdata, sshkey, resourceGroup, storageAccount string, network Network) (*Machine, error) {
+	subnet := network.subnet
 
 	ip, err := a.createPublicIP(resourceGroup)
 	if err != nil {

--- a/platform/api/azure/instance.go
+++ b/platform/api/azure/instance.go
@@ -182,8 +182,8 @@ func (a *API) CreateInstance(name, userdata, sshkey, resourceGroup, storageAccou
 		return nil, fmt.Errorf("couldn't get VM ID")
 	}
 	ipName := *ip.Name
-	if a.opts.UsePrivateIps {
-		// empty IP name means instance is accessible via private ip address
+	if a.opts.UsePrivateIPs {
+		// empty IP name means instance is accessible via private IP address
 		ipName = ""
 	}
 	publicaddr, privaddr, err := a.GetIPAddresses(*nic.Name, ipName, resourceGroup)

--- a/platform/api/azure/instance.go
+++ b/platform/api/azure/instance.go
@@ -181,8 +181,12 @@ func (a *API) CreateInstance(name, userdata, sshkey, resourceGroup, storageAccou
 	if vm.Name == nil {
 		return nil, fmt.Errorf("couldn't get VM ID")
 	}
-
-	publicaddr, privaddr, err := a.GetIPAddresses(*nic.Name, *ip.Name, resourceGroup)
+	ipName := *ip.Name
+	if a.opts.UsePrivateIps {
+		// empty IP name means instance is accessible via private ip address
+		ipName = ""
+	}
+	publicaddr, privaddr, err := a.GetIPAddresses(*nic.Name, ipName, resourceGroup)
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +196,7 @@ func (a *API) CreateInstance(name, userdata, sshkey, resourceGroup, storageAccou
 		PublicIPAddress:  publicaddr,
 		PrivateIPAddress: privaddr,
 		InterfaceName:    *nic.Name,
-		PublicIPName:     *ip.Name,
+		PublicIPName:     ipName,
 	}, nil
 }
 

--- a/platform/api/azure/instance.go
+++ b/platform/api/azure/instance.go
@@ -59,6 +59,7 @@ func (a *API) getVMParameters(name, userdata, sshkey, storageAccountURI string, 
 		osProfile.CustomData = &ud
 	}
 	var imgRef *compute.ImageReference
+	var plan *compute.Plan
 	if a.opts.DiskURI != "" {
 		imgRef = &compute.ImageReference{
 			ID: &a.opts.DiskURI,
@@ -70,6 +71,11 @@ func (a *API) getVMParameters(name, userdata, sshkey, storageAccountURI string, 
 			Sku:       &a.opts.Sku,
 			Version:   &a.opts.Version,
 		}
+		plan = &compute.Plan{
+			Publisher: imgRef.Publisher,
+			Product:   imgRef.Offer,
+			Name:      imgRef.Sku,
+		}
 	}
 	return compute.VirtualMachine{
 		Name:     &name,
@@ -77,6 +83,7 @@ func (a *API) getVMParameters(name, userdata, sshkey, storageAccountURI string, 
 		Tags: map[string]*string{
 			"createdBy": util.StrToPtr("mantle"),
 		},
+		Plan: plan,
 		VirtualMachineProperties: &compute.VirtualMachineProperties{
 			HardwareProfile: &compute.HardwareProfile{
 				VMSize: compute.VirtualMachineSizeTypes(a.opts.Size),

--- a/platform/api/azure/network.go
+++ b/platform/api/azure/network.go
@@ -79,7 +79,7 @@ func (a *API) PrepareNetworkResources(resourceGroup string) (Network, error) {
 	if err != nil {
 		return Network{}, err
 	}
-	return Network{subnet}, err
+	return Network{subnet}, nil
 }
 
 func (a *API) createVirtualNetwork(resourceGroup string) error {

--- a/platform/api/azure/options.go
+++ b/platform/api/azure/options.go
@@ -35,7 +35,9 @@ type Options struct {
 	Size             string
 	Location         string
 	HyperVGeneration string
+	VnetSubnetName   string
 	UseGallery       bool
+	UsePrivateIps    bool
 
 	SubscriptionName string
 	SubscriptionID   string

--- a/platform/api/azure/options.go
+++ b/platform/api/azure/options.go
@@ -37,7 +37,7 @@ type Options struct {
 	HyperVGeneration string
 	VnetSubnetName   string
 	UseGallery       bool
-	UsePrivateIps    bool
+	UsePrivateIPs    bool
 
 	SubscriptionName string
 	SubscriptionID   string

--- a/platform/machine/azure/cluster.go
+++ b/platform/machine/azure/cluster.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 
 	"github.com/flatcar-linux/mantle/platform"
+	"github.com/flatcar-linux/mantle/platform/api/azure"
 	"github.com/flatcar-linux/mantle/platform/conf"
 )
 
@@ -30,6 +31,7 @@ type cluster struct {
 	sshKey         string
 	ResourceGroup  string
 	StorageAccount string
+	Network        azure.Network
 }
 
 func (ac *cluster) vmname() string {
@@ -46,7 +48,7 @@ func (ac *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 		return nil, err
 	}
 
-	instance, err := ac.flight.api.CreateInstance(ac.vmname(), conf.String(), ac.sshKey, ac.ResourceGroup, ac.StorageAccount)
+	instance, err := ac.flight.api.CreateInstance(ac.vmname(), conf.String(), ac.sshKey, ac.ResourceGroup, ac.StorageAccount, ac.Network)
 	if err != nil {
 		return nil, err
 	}

--- a/platform/machine/azure/flight.go
+++ b/platform/machine/azure/flight.go
@@ -96,6 +96,7 @@ func NewFlight(opts *azure.Options) (platform.Flight, error) {
 
 		af.Network, err = af.api.PrepareNetworkResources(af.ImageResourceGroup)
 		if err != nil {
+			af.Destroy()
 			return nil, err
 		}
 
@@ -188,6 +189,7 @@ func (af *flight) NewCluster(rconf *platform.RuntimeConfig) (platform.Cluster, e
 
 		ac.Network, err = af.api.PrepareNetworkResources(ac.ResourceGroup)
 		if err != nil {
+			ac.Destroy()
 			return nil, err
 		}
 	}

--- a/platform/machine/azure/flight.go
+++ b/platform/machine/azure/flight.go
@@ -40,6 +40,7 @@ type flight struct {
 	FakeSSHKey          string
 	ImageResourceGroup  string
 	ImageStorageAccount string
+	Network             azure.Network
 }
 
 // NewFlight creates an instance of a Flight suitable for spawning
@@ -93,7 +94,7 @@ func NewFlight(opts *azure.Options) (platform.Flight, error) {
 			return nil, err
 		}
 
-		_, err = af.api.PrepareNetworkResources(af.ImageResourceGroup)
+		af.Network, err = af.api.PrepareNetworkResources(af.ImageResourceGroup)
 		if err != nil {
 			return nil, err
 		}
@@ -173,7 +174,7 @@ func (af *flight) NewCluster(rconf *platform.RuntimeConfig) (platform.Cluster, e
 	if af.ImageResourceGroup != "" && af.ImageStorageAccount != "" {
 		ac.ResourceGroup = af.ImageResourceGroup
 		ac.StorageAccount = af.ImageStorageAccount
-
+		ac.Network = af.Network
 	} else {
 		ac.ResourceGroup, err = af.api.CreateResourceGroup("kola-cluster")
 		if err != nil {
@@ -185,7 +186,7 @@ func (af *flight) NewCluster(rconf *platform.RuntimeConfig) (platform.Cluster, e
 			return nil, err
 		}
 
-		_, err = af.api.PrepareNetworkResources(ac.ResourceGroup)
+		ac.Network, err = af.api.PrepareNetworkResources(ac.ResourceGroup)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
# azure private networking

Add kola support for creating instances in an existing virtual network/subnet, and addressing them using private IP addresses. This assumes that we are either also located in the specified virtual network or can otherwise access it via VPN.

The `--azure-use-private-ips` option only makes sense when used together with the `--azure-vnet-subnet-name`, as otherwise kola creates the vnet and it won't be peered or have a VPN configured.

## How to use

```
./bin/kola spawn --platform azure --verbose --azure-location <location> --azure-publisher kinvolk --azure-offer flatcar-container-linux-free  --azure-sku alpha --azure-use-private-ips=true --azure-vnet-subnet-name <vnet-name>/<subnet-name>
```

## Testing done

Ran the command from the "how-to-use" section.

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
