### PR TITLE
kola/tests: Add test for runtime switching to cgroupv1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `update-offer` ore subcommand for AWS marketplace publishing ([#282](https://github.com/flatcar-linux/mantle/pull/282))
 - kola test `cl.swap_activation` for swap activation with CLC ([#284](https://github.com/flatcar-linux/mantle/pull/284))
 - Azure: support for running Kola within an existing vnet and with private addressing ([#295](https://github.com/flatcar-linux/mantle/pull/295))
+- kola tests `cl.cgroupv1` and `kubeadm.*.*.cgroupv1.base` that test functionality with cgroupv1 ([#298](https://github.com/flatcar-linux/mantle/pull/298))
 
 ### Changed
 - removed `packet` occurrences in favor of `equinixmetal` ([#277](https://github.com/flatcar-linux/mantle/pull/277))

--- a/kola/tests/kubeadm/templates.go
+++ b/kola/tests/kubeadm/templates.go
@@ -16,6 +16,14 @@ package kubeadm
 var (
 	workerConfig = `systemd:
   units:
+{{ if .cgroupv1 }}
+    - name: containerd.service
+      dropins:
+      - name: 10-use-cgroupfs.conf
+        contents: |
+          [Service]
+          Environment=CONTAINERD_CONFIG=/usr/share/containerd/config-cgroupfs.toml
+{{ end }}
     - name: prepare-cni-plugins.service
       enabled: true
       contents: |
@@ -52,6 +60,10 @@ var (
         WantedBy=multi-user.target
 storage:
   files:
+{{ if .cgroupv1 }}
+    - path: /etc/flatcar-cgroupv1
+      mode: 0444
+{{ end }}
     - path: /opt/cni-plugins-linux-{{ .Arch }}-{{ .CNIVersion }}.tgz
       filesystem: root
       mode: 0644
@@ -108,7 +120,13 @@ storage:
           }`
 
 	masterConfig = `systemd:
-  units:
+  units:{{ if .cgroupv1 }}
+    - name: containerd.service
+      dropins:
+      - name: 10-use-cgroupfs.conf
+        contents: |
+          [Service]
+          Environment=CONTAINERD_CONFIG=/usr/share/containerd/config-cgroupfs.toml{{ end }}
     - name: prepare-cni-plugins.service
       enabled: true
       contents: |
@@ -144,7 +162,9 @@ storage:
         [Install]
         WantedBy=multi-user.target
 storage:
-  files:
+  files:{{ if .cgroupv1 }}
+    - path: /etc/flatcar-cgroupv1
+      mode: 0444{{ end }}
     - path: /opt/cni-plugins-linux-{{ .Arch }}-{{ .CNIVersion }}.tgz
       filesystem: root
       mode: 0644

--- a/kola/tests/misc/cgroup1.go
+++ b/kola/tests/misc/cgroup1.go
@@ -1,0 +1,102 @@
+// Copyright The Mantle Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package misc
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/coreos/go-semver/semver"
+
+	"github.com/flatcar-linux/mantle/kola/cluster"
+	"github.com/flatcar-linux/mantle/kola/register"
+	"github.com/flatcar-linux/mantle/kola/tests/coretest"
+	"github.com/flatcar-linux/mantle/platform/conf"
+)
+
+func init() {
+	config := conf.Ignition(`{
+"ignition": { "version": "2.0.0" },
+  "storage": {
+    "files": [{
+      "filesystem": "root",
+      "path": "/etc/flatcar-cgroupv1",
+      "contents": { "source": "data:," },
+      "mode": 420
+    }]
+  }
+}`)
+
+	register.Register(&register.Test{
+		Run:         CgroupV1Test,
+		ClusterSize: 1,
+		Name:        "cl.cgroupv1",
+		UserData:    config,
+		NativeFuncs: map[string]func() error{
+			"CgroupMounts": TestCgroup1Mounts,
+		},
+		Distros:    []string{"cl"},
+		MinVersion: semver.Version{Major: 3140},
+	})
+}
+
+func CgroupV1Test(c cluster.TestCluster) {
+	tests := c.ListNativeFunctions()
+	for _, name := range tests {
+		c.RunNative(name, c.Machines()[0])
+	}
+}
+
+func TestCgroup1Mounts() error {
+	mounts, err := coretest.GetMountTable()
+	if err != nil {
+		return err
+	}
+	// check that we are no hybrid
+	for _, mount := range mounts {
+		if mount.FsType == "cgroup2" {
+			return fmt.Errorf("cgroup2 is mounted: %v", mount)
+		}
+	}
+	controllers := map[string]bool{
+		"blkio":        false,
+		"cpu":          false,
+		"cpuacct":      false,
+		"cpuset":       false,
+		"devices":      false,
+		"freezer":      false,
+		"hugetlb":      false,
+		"memory":       false,
+		"name=systemd": false,
+		"net_cls":      false,
+		"net_prio":     false,
+		"perf_event":   false,
+		"pids":         false,
+	}
+	// check that we have all legacy controllers
+	for _, mount := range mounts {
+		if mount.FsType == "cgroup" {
+			controllerFound := false
+			for _, opt := range mount.Options {
+				if _, ok := controllers[opt]; ok {
+					controllers[opt] = true
+					controllerFound = true
+				}
+			}
+			if !controllerFound {
+				return fmt.Errorf("unexpected controller: %v", mount)
+			}
+		}
+	}
+	missingControllers := make([]string, 0)
+	for k, v := range controllers {
+		if !v {
+			missingControllers = append(missingControllers, k)
+		}
+	}
+	if len(missingControllers) > 0 {
+		return fmt.Errorf("cgroup controllers missing: %s", strings.Join(missingControllers, ","))
+	}
+	return nil
+}


### PR DESCRIPTION
# kola/tests: Add test for runtime switching to cgroupv1

Add test illustrating switching to cgroupv1 with no reboot.

## How to use

Run test with this PR: https://github.com/flatcar-linux/coreos-overlay/pull/1666

## Testing done

CI running

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
