### PR TITLE
kola/tests/ignition/oem: Check for written file contents

### DIFF
--- a/kola/tests/ignition/oem.go
+++ b/kola/tests/ignition/oem.go
@@ -91,6 +91,11 @@ func init() {
 
 // reusePartition asserts that even if the config uses a different fs format, we keep using `btrfs`.
 func reusePartition(c cluster.TestCluster) {
+	grub := c.MustSSH(c.Machines()[0], `grep -m 1 '^set linux_append="flatcar.autologin"$' /usr/share/oem/grub.cfg`)
+	if string(grub) != `set linux_append="flatcar.autologin"` {
+		c.Fatalf("did not find written grub entry: %s", string(grub))
+	}
+
 	out := c.MustSSH(c.Machines()[0], `lsblk --output FSTYPE,LABEL,MOUNTPOINT --json | jq -r '.blockdevices | .[] | select(.label=="OEM") | .fstype'`)
 
 	if string(out) != "btrfs" {


### PR DESCRIPTION
If the mount of the specified filesystem in Ignition is not correct,
we don't see the file written to the right disk.
Add a check that the correct file got written to.


## How to use

Should fail with current ignition v3 wip until the bootengine changes are in.

## Testing done

It passed on [main](http://jenkins.infra.kinvolk.io:8080/job/os/job/kola/job/qemu/3754/console).

As expected, it fails on the [v3 wip](http://jenkins.infra.kinvolk.io:8080/job/os/job/kola/job/qemu/3755/console) without bootengine fixes:
```
 Error: "cluster.go:130: \"grep -m 1 '^set linux_append=\\\"flatcar.autologin\\\"$' /usr/share/oem/grub.cfg\" failed: output , status Process exited with status 1"
```