### PR TITLE
Jenkinsfile: keep artifacts from 3 latest builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 #!groovy
 
 properties([
-    buildDiscarder(logRotator(daysToKeepStr: '20', numToKeepStr: '30')),
+    buildDiscarder(logRotator(daysToKeepStr: '20', numToKeepStr: '30', artifactNumToKeepStr: '3')),
 
     [$class: 'CopyArtifactPermissionProperty',
      projectNames: '*'],


### PR DESCRIPTION
Artifacts take space and we only use the latest artifacts when running tests so there is
no need for us to store more than the last 3.
