### PR TITLE
Jenkinsfile: flip default for archive artifacts to "true"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ properties([
 
     pipelineTriggers([pollSCM('H/15 * * * *')]),
     parameters([
-        booleanParam(name: 'ARCHIVE_ARTIFACTS', defaultValue: false),
+        booleanParam(name: 'ARCHIVE_ARTIFACTS', defaultValue: true),
         booleanParam(name: 'CLEAN', defaultValue: true)
     ])
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,10 @@ properties([
     [$class: 'CopyArtifactPermissionProperty',
      projectNames: '*'],
 
-    pipelineTriggers([pollSCM('H/15 * * * *')]),
+    pipelineTriggers([
+        pollSCM('H/15 * * * *'),
+        githubPush(),
+    ]),
     parameters([
         booleanParam(name: 'ARCHIVE_ARTIFACTS', defaultValue: true),
         booleanParam(name: 'CLEAN', defaultValue: true)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,10 +2,7 @@
 
 properties([
     buildDiscarder(logRotator(daysToKeepStr: '20', numToKeepStr: '30', artifactNumToKeepStr: '3')),
-
-    [$class: 'CopyArtifactPermissionProperty',
-     projectNames: '*'],
-
+    copyArtifactPermission('*'),
     pipelineTriggers([
         pollSCM('H/15 * * * *'),
         githubPush(),


### PR DESCRIPTION
# Jenkinsfile: flip default for archive artifacts to "true"

Now that we keep only the 3 latest build aritfacts it is perfectly fine
to enable artifact archiving for all branch/PR builds.

This will mean people no longer need to manually trigger a rebuild to test mantle changes.

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
