### PR TITLE
platform/api/equinixmetal: wipe disks before installing

### DIFF
--- a/platform/api/equinixmetal/api.go
+++ b/platform/api/equinixmetal/api.go
@@ -362,6 +362,7 @@ ExecStart=/usr/bin/curl --retry-delay 1 --retry 120 --retry-connrefused --retry-
 # We don't verify signatures because the iPXE script isn't verified either
 # (and, in fact, is transferred over HTTP)
 
+ExecStartPre=-/bin/bash -c 'shopt -s nullglob; for disk in /dev/*da? /dev/nvme?n1; do wipefs --all --force ${disk}; done'
 ExecStart=/usr/bin/flatcar-install -s -f image.bin.bz2 %v /userdata
 
 ExecStart=/usr/bin/systemctl --no-block isolate reboot.target


### PR DESCRIPTION
# platform/api/equinixmetal: wipe disks before installing

On EM disk names are not stable and may change across reboots. This is
generally not a problem, but since we started reusing machines, it is
much more likely that there will be a leftover flatcar installation on
one disk and we are now installing to the second. This messes with some
tests because partitions from both disks may be mixed up when mounting
by label. Fix this by wiping the partition tables from disks on
reinstallation.

This should resolve a flake we've seen with cl.ignition.oem.regular, and others where "expected /dev/sda found /dev/sdb" show up.

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
