### PR TITLE
platform/api/equinixmetal: fix disk wipe

### DIFF
--- a/platform/api/equinixmetal/api.go
+++ b/platform/api/equinixmetal/api.go
@@ -363,7 +363,7 @@ ExecStart=/usr/bin/curl --retry-delay 1 --retry 120 --retry-connrefused --retry-
 # (and, in fact, is transferred over HTTP)
 
 ExecStartPre=-/bin/bash -c 'lvchange -an /dev/mapper/*'
-ExecStartPre=-/bin/bash -c 'shopt -s nullglob; for disk in /dev/*da? /dev/nvme?n1; do wipefs --all --force $${disk}; done'
+ExecStartPre=-/bin/bash -c 'shopt -s nullglob; for disk in /dev/*d? /dev/nvme?n1; do wipefs --all --force $${disk}; done'
 ExecStart=/usr/bin/flatcar-install -s -f image.bin.bz2 %v /userdata
 
 ExecStart=/usr/bin/systemctl --no-block isolate reboot.target

--- a/platform/api/equinixmetal/api.go
+++ b/platform/api/equinixmetal/api.go
@@ -362,6 +362,7 @@ ExecStart=/usr/bin/curl --retry-delay 1 --retry 120 --retry-connrefused --retry-
 # We don't verify signatures because the iPXE script isn't verified either
 # (and, in fact, is transferred over HTTP)
 
+ExecStartPre=-/bin/bash -c 'lvchange -an /dev/mapper/*'
 ExecStartPre=-/bin/bash -c 'shopt -s nullglob; for disk in /dev/*da? /dev/nvme?n1; do wipefs --all --force $${disk}; done'
 ExecStart=/usr/bin/flatcar-install -s -f image.bin.bz2 %v /userdata
 

--- a/platform/api/equinixmetal/api.go
+++ b/platform/api/equinixmetal/api.go
@@ -362,7 +362,7 @@ ExecStart=/usr/bin/curl --retry-delay 1 --retry 120 --retry-connrefused --retry-
 # We don't verify signatures because the iPXE script isn't verified either
 # (and, in fact, is transferred over HTTP)
 
-ExecStartPre=-/bin/bash -c 'shopt -s nullglob; for disk in /dev/*da? /dev/nvme?n1; do wipefs --all --force ${disk}; done'
+ExecStartPre=-/bin/bash -c 'shopt -s nullglob; for disk in /dev/*da? /dev/nvme?n1; do wipefs --all --force $${disk}; done'
 ExecStart=/usr/bin/flatcar-install -s -f image.bin.bz2 %v /userdata
 
 ExecStart=/usr/bin/systemctl --no-block isolate reboot.target


### PR DESCRIPTION
- platform/api/equinixmetal: fix disk wipe
    
    The "disk" variable got substituted as argument for bash from the unit
    instead of inside bash as shell variable.
    Use escaping to prevent env var substitution inside the unit.
- platform/api/equinixmetal: disable LVM volumes before wiping the disks
    
    The autodetection of LVM volumes can happen now that we recycle
    baremetal instances through a PXE install. For the wipe to work and the
    flatcar-install free disk detection we need to disable any LVM volume
    first.
- platform/api/equinixmetal: delete any /dev/XdX devices
    
    We don't want to only wipe the partitions but the full device.
    Also, we have to look for vda, sdb, and xvda.

## How to use

## Testing done

none except that the quoting is now right