### PR TITLE
Add private network support to qemu-unpriv platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - kola test `cl.swap_activation` for swap activation with CLC ([#284](https://github.com/flatcar-linux/mantle/pull/284))
 - Azure: support for running Kola within an existing vnet and with private addressing ([#295](https://github.com/flatcar-linux/mantle/pull/295))
 - kola tests `cl.cgroupv1` and `kubeadm.*.*.cgroupv1.base` that test functionality with cgroupv1 ([#298](https://github.com/flatcar-linux/mantle/pull/298))
+- Added private network support to qemu-unpriv platform ([#307](https://github.com/flatcar-linux/mantle/pull/307))
 
 ### Changed
 - removed `packet` occurrences in favor of `equinixmetal` ([#277](https://github.com/flatcar-linux/mantle/pull/277))

--- a/kola/tests/docker/docker.go
+++ b/kola/tests/docker/docker.go
@@ -66,8 +66,7 @@ func init() {
 		ClusterSize: 2,
 		Name:        "docker.network",
 		Distros:     []string{"cl"},
-
-		// qemu-unpriv machines cannot communicate
+		// No idea why Docker containers cannot reach each the other VM
 		ExcludePlatforms: []string{"qemu-unpriv"},
 	})
 	register.Register(&register.Test{
@@ -109,9 +108,6 @@ storage:
 passwd:
   users:
   - name: dockremap`),
-
-		// qemu-unpriv machines cannot communicate
-		ExcludePlatforms: []string{"qemu-unpriv"},
 	})
 
 	// This test covers all functionality that should be quick to run and can be
@@ -223,12 +219,6 @@ systemd:
   units:
    - name: docker.service
      enable: true`),
-
-		// https://github.com/coreos/mantle/issues/999
-		// On the qemu-unpriv platform the DHCP provides no data, pre-systemd 241 the DHCP server sending
-		// no routes to the link to spin in the configuring state. docker.service pulls in the network-online
-		// target which causes the basic machine checks to fail
-		ExcludePlatforms: []string{"qemu-unpriv"},
 	})
 }
 

--- a/kola/tests/etcd/discovery.go
+++ b/kola/tests/etcd/discovery.go
@@ -39,8 +39,7 @@ func init() {
   listen_peer_urls:            http://{PRIVATE_IPV4}:2380
   initial_advertise_peer_urls: http://{PRIVATE_IPV4}:2380
   discovery:                   $discovery`),
-		Distros:          []string{"cl"},
-		ExcludePlatforms: []string{"qemu-unpriv"},
+		Distros: []string{"cl"},
 	})
 
 	register.Register(&register.Test{
@@ -57,8 +56,7 @@ etcd:
   initial_advertise_peer_urls: http://{PRIVATE_IPV4}:2380
   discovery:                   $discovery
   enable_v2:                   true`),
-		ExcludePlatforms: []string{"esx", "qemu-unpriv"}, // etcd-member requires ct rendering and networking
-		Distros:          []string{"cl"},
+		Distros: []string{"cl"},
 	})
 
 	register.Register(&register.Test{
@@ -75,8 +73,7 @@ etcd:
   listen_peer_urls:            http://0.0.0.0:2380
   initial_advertise_peer_urls: http://127.0.0.1:2380
 `, uuid.New())),
-		Distros:          []string{"cl"},
-		ExcludePlatforms: []string{"qemu-unpriv"},
+		Distros: []string{"cl"},
 	})
 }
 

--- a/kola/tests/flannel/flannel.go
+++ b/kola/tests/flannel/flannel.go
@@ -63,22 +63,22 @@ systemd:
 
 func init() {
 	register.Register(&register.Test{
-		Run:              udp,
-		ClusterSize:      3,
-		Name:             "cl.flannel.udp",
-		Distros:          []string{"cl"},
+		Run:         udp,
+		ClusterSize: 3,
+		Name:        "cl.flannel.udp",
+		Distros:     []string{"cl"},
+		// Fails to work for some reason
 		ExcludePlatforms: []string{"qemu-unpriv"},
 		UserData:         flannelConf.Subst("$type", "udp"),
 		Architectures:    []string{"amd64"},
 	})
 
 	register.Register(&register.Test{
-		Run:              vxlan,
-		ClusterSize:      3,
-		Name:             "cl.flannel.vxlan",
-		Distros:          []string{"cl"},
-		ExcludePlatforms: []string{"qemu-unpriv"},
-		UserData:         flannelConf.Subst("$type", "vxlan"),
+		Run:         vxlan,
+		ClusterSize: 3,
+		Name:        "cl.flannel.vxlan",
+		Distros:     []string{"cl"},
+		UserData:    flannelConf.Subst("$type", "vxlan"),
 	})
 }
 

--- a/kola/tests/ignition/security.go
+++ b/kola/tests/ignition/security.go
@@ -80,7 +80,7 @@ func init() {
 		// ESX: Currently Ignition does not support static IPs during the initramfs
 		// DO: https://github.com/coreos/bugs/issues/2205
 		// EquinixMetal & QEMU: https://github.com/coreos/ignition/issues/645
-		ExcludePlatforms: []string{"esx", "do", "equinixmetal"},
+		ExcludePlatforms: []string{"esx", "do", "equinixmetal", "qemu-unpriv"},
 		Distros:          []string{"cl", "fcos", "rhcos"},
 	})
 }

--- a/kola/tests/ignition/systemd.go
+++ b/kola/tests/ignition/systemd.go
@@ -65,11 +65,6 @@ func init() {
         }]
     }
 }`),
-		// https://github.com/coreos/mantle/issues/999
-		// On the qemu-unpriv platform the DHCP provides no data, pre-systemd 241 the DHCP server sending
-		// no routes to the link to spin in the configuring state. nfs-server.service pulls in the network-online
-		// target which causes the basic machine checks to fail
-		ExcludePlatforms: []string{"qemu-unpriv"},
 		// FCOS just ships the client (see
 		// https://github.com/coreos/fedora-coreos-tracker/issues/121).
 		// Should probably just pick a different unit to test with, though

--- a/kola/tests/kubeadm/kubeadm.go
+++ b/kola/tests/kubeadm/kubeadm.go
@@ -155,9 +155,10 @@ func init() {
 				}
 
 				register.Register(&register.Test{
-					Name:             fmt.Sprintf("kubeadm.%s.%s%s.base", version, CNI, cgroupSuffix),
-					Distros:          []string{"cl"},
-					ExcludePlatforms: []string{"esx"},
+					Name:    fmt.Sprintf("kubeadm.%s.%s%s.base", version, CNI, cgroupSuffix),
+					Distros: []string{"cl"},
+					// Network config problems in esx and qemu-unpriv
+					ExcludePlatforms: []string{"esx", "qemu-unpriv"},
 					Run: func(c cluster.TestCluster) {
 						kubeadmBaseTest(c, testParams)
 					},

--- a/kola/tests/locksmith/locksmith.go
+++ b/kola/tests/locksmith/locksmith.go
@@ -47,8 +47,7 @@ etcd:
   listen_peer_urls:            http://{PRIVATE_IPV4}:2380
   discovery:                   $discovery
   enable_v2:                   true`),
-		Distros:          []string{"cl"},
-		ExcludePlatforms: []string{"qemu-unpriv"},
+		Distros: []string{"cl"},
 	})
 	register.Register(&register.Test{
 		Name:        "coreos.locksmith.reboot",

--- a/kola/tests/misc/network.go
+++ b/kola/tests/misc/network.go
@@ -39,16 +39,14 @@ func init() {
   units:
     - name: docker.service
       enabled: true`),
-		MinVersion:       semver.Version{Major: 1967},
-		ExcludePlatforms: []string{"qemu-unpriv"},
+		MinVersion: semver.Version{Major: 1967},
 	})
 	register.Register(&register.Test{
-		Run:              NetworkListeners,
-		ClusterSize:      1,
-		Name:             "cl.network.listeners.legacy",
-		Distros:          []string{"cl"},
-		EndVersion:       semver.Version{Major: 1967},
-		ExcludePlatforms: []string{"qemu-unpriv"},
+		Run:         NetworkListeners,
+		ClusterSize: 1,
+		Name:        "cl.network.listeners.legacy",
+		Distros:     []string{"cl"},
+		EndVersion:  semver.Version{Major: 1967},
 	})
 	register.Register(&register.Test{
 		Run:              NetworkInitramfsSecondBoot,

--- a/kola/tests/misc/nfs.go
+++ b/kola/tests/misc/nfs.go
@@ -56,8 +56,7 @@ func init() {
 
 		// Disabled on Azure because setting hostname
 		// is required at the instance creation level
-		// qemu-unpriv machines cannot communicate
-		ExcludePlatforms: []string{"azure", "qemu-unpriv"},
+		ExcludePlatforms: []string{"azure"},
 	})
 	// TODO: enable FCOS when FCCT exists
 	register.Register(&register.Test{
@@ -68,8 +67,7 @@ func init() {
 
 		// Disabled on Azure because setting hostname
 		// is required at the instance creation level
-		// qemu-unpriv machines cannot communicate
-		ExcludePlatforms: []string{"azure", "qemu-unpriv"},
+		ExcludePlatforms: []string{"azure"},
 	})
 }
 

--- a/kola/tests/misc/verity.go
+++ b/kola/tests/misc/verity.go
@@ -33,8 +33,10 @@ func init() {
 		ClusterSize: 1,
 		Name:        "cl.verity",
 		Distros:     []string{"cl"},
-		Flags:       []register.Flag{register.NoKernelPanicCheck},
-		MinVersion:  semver.Version{Major: 2943},
+		// Somehow hangs
+		ExcludePlatforms: []string{"qemu-unpriv"},
+		Flags:            []register.Flag{register.NoKernelPanicCheck},
+		MinVersion:       semver.Version{Major: 2943},
 	})
 }
 

--- a/kola/tests/systemd/journald.go
+++ b/kola/tests/systemd/journald.go
@@ -62,8 +62,7 @@ func init() {
 
 		// Disabled on Azure because setting hostname
 		// is required at the instance creation level
-		// qemu-unpriv machines cannot communicate
-		ExcludePlatforms: []string{"azure", "qemu-unpriv"},
+		ExcludePlatforms: []string{"azure"},
 	})
 }
 

--- a/kola/tests/torcx/torcx.go
+++ b/kola/tests/torcx/torcx.go
@@ -35,12 +35,6 @@ systemd:
     enable: true
 `),
 		Distros: []string{"cl"},
-
-		// https://github.com/coreos/mantle/issues/999
-		// On the qemu-unpriv platform the DHCP provides no data, pre-systemd 241 the DHCP server sending
-		// no routes to the link to spin in the configuring state. docker.service pulls in the network-online
-		// target which causes the basic machine checks to fail
-		ExcludePlatforms: []string{"qemu-unpriv"},
 	})
 }
 

--- a/platform/machine/unprivqemu/flight.go
+++ b/platform/machine/unprivqemu/flight.go
@@ -15,9 +15,12 @@
 package unprivqemu
 
 import (
+	"net"
 	"os"
 
 	"github.com/coreos/pkg/capnslog"
+
+	ctplatform "github.com/flatcar-linux/container-linux-config-transpiler/config/platform"
 
 	"github.com/flatcar-linux/mantle/platform"
 	"github.com/flatcar-linux/mantle/platform/machine/qemu"
@@ -40,7 +43,7 @@ var (
 )
 
 func NewFlight(opts *qemu.Options) (platform.Flight, error) {
-	bf, err := platform.NewBaseFlight(opts.Options, Platform, "")
+	bf, err := platform.NewBaseFlight(opts.Options, Platform, ctplatform.Custom)
 	if err != nil {
 		return nil, err
 	}
@@ -62,9 +65,14 @@ func (qf *flight) NewCluster(rconf *platform.RuntimeConfig) (platform.Cluster, e
 		return nil, err
 	}
 
+	l, err := net.Listen("tcp", "127.0.0.99:0")
+	if err != nil {
+		return nil, err
+	}
 	qc := &Cluster{
-		BaseCluster: bc,
-		flight:      qf,
+		BaseCluster:     bc,
+		flight:          qf,
+		mcastPortHolder: l,
 	}
 
 	qf.AddCluster(qc)

--- a/platform/machine/unprivqemu/machine.go
+++ b/platform/machine/unprivqemu/machine.go
@@ -31,6 +31,7 @@ type machine struct {
 	consolePath string
 	console     string
 	ip          string
+	privateAddr string
 }
 
 func (m *machine) ID() string {
@@ -42,7 +43,7 @@ func (m *machine) IP() string {
 }
 
 func (m *machine) PrivateIP() string {
-	return m.ip
+	return m.privateAddr
 }
 
 func (m *machine) RuntimeConf() platform.RuntimeConfig {


### PR DESCRIPTION
The "qemu" platform has the ability for VMs to connect to each other
    but the "qemu-unpriv" platform lacked it, and thus would skip many
    tests.
    Make the qemu-unpriv platform a viable mode for running kola tests
    by adding a private network. This private network only works through
    static or link-local IPv4 addresses (IPv6 would work though) and it
    seems that static addresses make things easier, thus they were chosen.
    Yet since the required setup can't be done in the initramfs, those
    tests that require initramfs private network access have to be skipped.
    The tests which now can run got marked so and those that didn't work
    before either but were forgotten to be excluded are now marked to be
    excluded. Somehow Docker containers can't yet reach the other VMs and
    the kubeadm tests have network config issues.



## How to use

```
kola run -d -k --parallel=4 --platform=qemu-unpriv --qemu-image flatcar_production_image.bin
```

While at it I corrected one esx exclusion which wasn't valid

## Testing done

All tests passed.

Ran `cl.etcd-member.v2-backup-restore` on esx with success

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
