### PR TITLE
platform/azure: switch to PremiumSSD for OS disk

### DIFF
--- a/platform/api/azure/instance.go
+++ b/platform/api/azure/instance.go
@@ -93,6 +93,9 @@ func (a *API) getVMParameters(name, userdata, sshkey, storageAccountURI string, 
 				OsDisk: &compute.OSDisk{
 					CreateOption: compute.DiskCreateOptionTypesFromImage,
 					DeleteOption: compute.DiskDeleteOptionTypesDelete,
+					ManagedDisk: &compute.ManagedDiskParameters{
+						StorageAccountType: compute.StorageAccountTypesPremiumLRS,
+					},
 				},
 			},
 			OsProfile: &osProfile,


### PR DESCRIPTION
# platform/azure: switch to PremiumSSD for OS disk

bpf.execsnoop times out frequently on Azure, it also takes longer than on other
platforms. Looking deeper suggests that slow disk performance may be the cause.
Switch to premium SSD for disk storage to improve disk performance and reduce
test flakiness.

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
