### PR TITLE
kola/tests/misc/grub.go: Try to fix grubnop test

### DIFF
--- a/kola/tests/misc/grub.go
+++ b/kola/tests/misc/grub.go
@@ -140,8 +140,21 @@ var (
 
 coreos:
   units:
-    - name: update-engine.service
-      mask: true
+    - name: stop-and-mask-update-engine.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Stop Update Engine
+        Conflicts=update-engine.service
+        Before=update-engine.service
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=true
+        ExecStart=/usr/bin/systemctl mask --now update-engine.service
+
+        [Install]
+        WantedBy=multi-user.target
 `)
 )
 


### PR DESCRIPTION
The mask clause in coreos-cloudinit was masking the unit and then
telling systemd to reload. With that, systemd noticed that update
engine is masked and killed it, but for some reason marked it as
failed.

Current approach is to have a unit that conflicts with update engine
and masks it. That way, systemd should stop update engine without
marking it as failed and then mask it.

CI passed: http://localhost:9091/job/os/job/kola/job/qemu/3993/