### PR TITLE
kola/tests/ignition: add luks test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Azure: support for running Kola within an existing vnet and with private addressing ([#295](https://github.com/flatcar-linux/mantle/pull/295))
 - kola tests `cl.cgroupv1` and `kubeadm.*.*.cgroupv1.base` that test functionality with cgroupv1 ([#298](https://github.com/flatcar-linux/mantle/pull/298))
 - Added private network support to qemu-unpriv platform ([#307](https://github.com/flatcar-linux/mantle/pull/307))
-- Ignition v3 support and tests ([#301](https://github.com/flatcar-linux/mantle/pull/301))
+- Ignition v3 support and tests ([#301](https://github.com/flatcar-linux/mantle/pull/301), [#311](https://github.com/flatcar-linux/mantle/pull/311))
 
 ### Changed
 - removed `packet` occurrences in favor of `equinixmetal` ([#277](https://github.com/flatcar-linux/mantle/pull/277))

--- a/kola/tests/ignition/luks.go
+++ b/kola/tests/ignition/luks.go
@@ -1,0 +1,50 @@
+// Copyright The Mantle Authors
+// Copyright 2020 Red Hat
+// SPDX-License-Identifier: Apache-2.0
+package ignition
+
+import (
+	"github.com/coreos/go-semver/semver"
+	"github.com/flatcar-linux/mantle/kola/cluster"
+	"github.com/flatcar-linux/mantle/kola/register"
+	"github.com/flatcar-linux/mantle/platform/conf"
+)
+
+func init() {
+	register.Register(&register.Test{
+		Name:        "cl.ignition.luks",
+		Run:         luksTest,
+		ClusterSize: 1,
+		Distros:     []string{"cl"},
+		MinVersion:  semver.Version{Major: 3185},
+		UserData: conf.Ignition(`{
+		  "ignition": {"version": "3.2.0"},
+		  "storage": {
+		    "luks": [{
+		      "name": "data",
+		      "device": "/dev/disk/by-partlabel/USR-B"
+		    }],
+		    "filesystems": [{
+		      "path": "/var/lib/data",
+		      "device": "/dev/disk/by-id/dm-name-data",
+		      "format": "ext4",
+		      "label": "DATA"
+		    }]
+		  },
+		  "systemd": {
+		    "units": [{
+		      "name": "var-lib-data.mount",
+		      "enabled": true,
+		      "contents": "[Mount]\nWhat=/dev/disk/by-label/DATA\nWhere=/var/lib/data\nType=ext4\n\n[Install]\nWantedBy=local-fs.target"
+		    }]
+		  }
+	  	}`),
+	})
+}
+
+func luksTest(c cluster.TestCluster) {
+	m := c.Machines()[0]
+
+	c.MustSSH(m, "sudo cryptsetup isLuks /dev/disk/by-partlabel/USR-B")
+	c.MustSSH(m, "systemctl is-active var-lib-data.mount")
+}


### PR DESCRIPTION
Ignition will set up a key-file based LUKS2 volume on a secondary disk
added to the instance.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

To be tested with: https://github.com/flatcar-linux/coreos-overlay/pull/1760 - tested here: http://jenkins.infra.kinvolk.io:8080/job/os/job/kola/job/qemu/4005/

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
