### PR TITLE
test/ignition: restrict test to a MinVersion

### DIFF
--- a/kola/tests/ignition/units.go
+++ b/kola/tests/ignition/units.go
@@ -4,6 +4,7 @@
 package ignition
 
 import (
+	"github.com/coreos/go-semver/semver"
 	"github.com/flatcar-linux/mantle/kola/cluster"
 	"github.com/flatcar-linux/mantle/kola/register"
 	"github.com/flatcar-linux/mantle/platform/conf"
@@ -39,7 +40,8 @@ func init() {
 		}]
     }
 }`),
-		Distros: []string{"cl"},
+		Distros:    []string{"cl"},
+		MinVersion: semver.Version{Major: 3185},
 	})
 }
 


### PR DESCRIPTION
Ignition 3 spec is available starting from 3185.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

no changelog.
