### PR TITLE
kola/tests/kubeadm: transform cilium output to valid ascii

### DIFF
--- a/kola/tests/kubeadm/templates.go
+++ b/kola/tests/kubeadm/templates.go
@@ -380,13 +380,14 @@ EOF
     kubectl apply -f kube-flannel.yml
 {{ end }}
 {{ if eq .CNI "cilium" }}
+    # iconv transforms the output to valid ascii so that jenkins TAP parser accepts it
     sudo tar -xf {{ .DownloadDir }}/cilium.tar.gz -C {{ .DownloadDir }}
     /opt/bin/cilium install \
         --config enable-endpoint-routes=true \
         --config cluster-pool-ipv4-cidr={{ .PodSubnet }} \
-        --version={{ .CiliumVersion }}
+        --version={{ .CiliumVersion }} 2>&1 | iconv --from-code utf-8 --to-code ascii//TRANSLIT
     # --wait will wait for status to report success
-    /opt/bin/cilium status --wait
+    /opt/bin/cilium status --wait 2>&1 | iconv --from-code utf-8 --to-code ascii//TRANSLIT
 {{ end }}
 } 1>&2
 

--- a/kola/tests/kubeadm/testdata/master-cilium-script.sh
+++ b/kola/tests/kubeadm/testdata/master-cilium-script.sh
@@ -85,13 +85,14 @@ EOF
 
 
 
+    # iconv transforms the output to valid ascii so that jenkins TAP parser accepts it
     sudo tar -xf /opt/bin/cilium.tar.gz -C /opt/bin
     /opt/bin/cilium install \
         --config enable-endpoint-routes=true \
         --config cluster-pool-ipv4-cidr=192.168.0.0/17 \
-        --version=v0.11.1
+        --version=v0.11.1 2>&1 | iconv --from-code utf-8 --to-code ascii//TRANSLIT
     # --wait will wait for status to report success
-    /opt/bin/cilium status --wait
+    /opt/bin/cilium status --wait 2>&1 | iconv --from-code utf-8 --to-code ascii//TRANSLIT
 
 } 1>&2
 


### PR DESCRIPTION
# kola/tests/kubeadm: transform cilium output to valid ascii

Cilium outputs unicode characters to console even when the locale does not
allow it. Iconv can convert the output to valid ascii (replacing characters with '?').

Validated that this works by writing a small java application that directly calls
org.tap4j.parser.Tap13Parser.parseFile.

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
