### PR TITLE
update tests

### DIFF
--- a/kola/tests/bpf/bpf.go
+++ b/kola/tests/bpf/bpf.go
@@ -59,7 +59,7 @@ func execsnoopTest(c cluster.TestCluster) {
 
 		// wait for the container and the `execsnoop` command to be correctly started before
 		// generating traffic.
-		if err := util.Retry(5, 2*time.Second, func() error {
+		if err := util.Retry(10, 2*time.Second, func() error {
 			_ = c.MustSSH(m, "docker ps")
 
 			// we first assert that the container is running and then the process too.

--- a/kola/tests/misc/cgroup1.go
+++ b/kola/tests/misc/cgroup1.go
@@ -37,7 +37,7 @@ func init() {
 			"CgroupMounts": TestCgroup1Mounts,
 		},
 		Distros:    []string{"cl"},
-		MinVersion: semver.Version{Major: 3140},
+		MinVersion: semver.Version{Major: 3033},
 	})
 }
 

--- a/platform/api/do/api.go
+++ b/platform/api/do/api.go
@@ -104,7 +104,7 @@ func (a *API) CreateImage(ctx context.Context, name, url string) (*godo.Image, e
 	if err != nil {
 		return nil, err
 	}
-	err = util.WaitUntilReady(10*time.Minute, 15*time.Second, func() (bool, error) {
+	err = util.WaitUntilReady(15*time.Minute, 15*time.Second, func() (bool, error) {
 		image, _, err := a.c.Images.GetByID(ctx, image.ID)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
# update tests
* bpf.execsnoop is still failing on Azure most of the time - double the launch timeout from ~10s to ~20s to see if that improves the situation
* DO image creation often takes around ~10m, even when switched to gzip compression, which is too tight with the selected timeout of 10m, change to 15m.
* cgroupv1 test can now run on flatcar stable 3033.

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
