### PR TITLE
platform/api/aws/ec2: don't abort on errors from StopInstance

### DIFF
--- a/platform/api/aws/ec2.go
+++ b/platform/api/aws/ec2.go
@@ -230,7 +230,7 @@ func (a *API) TerminateInstances(ids []string) error {
 		Force:       util.BoolToPtr(true),
 	}
 	if _, err := a.ec2.StopInstances(stopInput); err != nil {
-		return err
+		plog.Warningf("ec2 failed to stop instance: %v", err)
 	}
 
 	input := &ec2.TerminateInstancesInput{


### PR DESCRIPTION
# platform/api/aws/ec2: don't abort on errors from StopInstance

To prevent the command for failing when an instance is stuck in pending state as here:

Couldn't gc: IncorrectInstanceState: Instance 'i-08333eba1b58744ba' cannot be stopped as it has never reached the 'running' state.

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
