### PR TITLE
kubeadm/template: update ipv4 fetching from metadata

### DIFF
--- a/kola/tests/kubeadm/templates.go
+++ b/kola/tests/kubeadm/templates.go
@@ -462,7 +462,7 @@ cat << EOF > worker-config.yaml
 EOF
 
 systemctl start --quiet coreos-metadata
-ipv4=$(cat /run/metadata/flatcar | grep -v IPV6 | grep IP | grep -E '(PRIVATE|LOCAL|DYNAMIC)' | cut -d = -f 2)
+ipv4=$(cat /run/metadata/flatcar | grep -v -E '(IPV6|GATEWAY)' | grep IP | grep -E '(PRIVATE|LOCAL|DYNAMIC)' | cut -d = -f 2)
 
 kubeadm join --config worker-config.yaml --node-name "${ipv4}"`
 )


### PR DESCRIPTION
with afterburn update, a new field appears for EquinixMetal:
  * `AFTERBURN_PACKET_IPV4_PRIVATE_GATEWAY_0`

This one was caught by the grep and `ipv4` value was composed of two
values:
  * `AFTERBURN_PACKET_IPV4_PRIVATE_0`
  * `AFTERBURN_PACKET_IPV4_PRIVATE_GATEWAY_0`

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

Tested in there: https://github.com/flatcar-linux/coreos-overlay/pull/1769

- [x] No changelog required
