### PR TITLE
kola: skip Ignition kargs test on Equinix Metal

### DIFF
--- a/kola/tests/ignition/kernel.go
+++ b/kola/tests/ignition/kernel.go
@@ -23,6 +23,9 @@ func init() {
 		  }
 		}`),
 		MinVersion: semver.Version{Major: 3185},
+		// The additional reboot causes a large waiting time
+		// and it's enough to test this on QEMU
+		ExcludePlatforms: []string{"equinixmetal"},
 	})
 }
 


### PR DESCRIPTION
The Ignition kargs test hits mantle's provisioning timeout due to the
additional reboot.
Since we don't really need this test to run on Equinix Metal since
running it on QEMU is equally good, we can skip it.


## How to use


## Testing done

