### PR TITLE
.github: Publish mantle container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,58 @@
+name: Build docker image
+on:
+  push:
+    branches:
+      - 'flatcar-master'
+  pull_request:
+    branches:
+      - 'flatcar-master'
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: flatcar-linux/mantle
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+
+    - name: Get tag name
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        tags: |
+          type=sha,event=branch,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }},prefix=git-,suffix=,format=long
+          type=ref,event=pr
+          type=ref,event=tag
+
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v1
+      with:
+        platforms: all
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to registry
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: true
+        platforms: linux/amd64,linux/arm64/v8
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# golang:1.17 is based on debian:11, this is important to ensure we have libc compatibility for the copied binary
+
+FROM docker.io/library/golang:1.17 as builder
+ENV CGO_ENABLED=1
+COPY . /usr/src/mantle
+RUN cd /usr/src/mantle && ./build
+
+FROM docker.io/library/debian:11
+RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -y qemu-utils qemu-system-x86 qemu-system-aarch64 qemu-efi-aarch64 seabios ovmf lbzip2 sudo dnsmasq gnupg2 git curl iptables nftables dns-root-data ca-certificates sqlite3
+COPY --from=builder /usr/src/mantle/bin /usr/local/bin
+RUN printf '#!/bin/sh\n# Workaround for kola to find its kolet binaries, this script is stored in sbin to get precedence\nexec /usr/local/bin/kola "$@"\n' > /usr/local/sbin/kola
+RUN chmod +x /usr/local/sbin/kola
+RUN ln -s /usr/share/seabios/bios-256k.bin /usr/share/qemu/bios-256k.bin
+
+# For KVM to work, run the resulting container as: docker run --privileged --net host -v /dev:/dev --rm -it TAG


### PR DESCRIPTION
A container image addresses the needs of running arm64 kola tests
    without QEMU emulation but with KVM on arm64 hardware because there is
    no native Flatcar SDK for arm64 yet, and it also allows us to have a
    single place that provides a particular version of the mantle binaries
    that is more lightweight than the full SDK where rebuilding the ebuild
    package is currently needed.
    The container image is published for the main branch but uses the git
    SHA commit ID as image tag which should be updated in the "scripts"
    repository.
    There is no garbage collection yet to remove images created by PR
    events.


## How to use

To be used from the scripts repo in the ci-automation pipeline

## Testing done

For this PR an image `mantle:pr-323` was built. Checked that it gets updated on force push.
In https://github.com/pothos/mantle a `mantle:git-COMMITID` image was built for flatcar-master.

Ran `kola run -d --platform=qemu-unpriv --qemu-image /w/flatcar_production_image.bin cl.basic` inside the container for amd64 and `kola run -d --platform=qemu --board arm64-usr --qemu-bios=/flatcar_production_qemu_uefi_efi_code.fd --qemu-image /flatcar_production_image.bin cl.basic` on an arm64 host