### PR TITLE
kola/tests/misc: add testcase for oem-gce service running on GCP

### DIFF
--- a/kola/tests/misc/gcp.go
+++ b/kola/tests/misc/gcp.go
@@ -1,0 +1,30 @@
+// Copyright The Mantle Authors.
+// SPDX-License-Identifier: Apache-2.0
+package misc
+
+import (
+	"github.com/flatcar-linux/mantle/kola/cluster"
+	"github.com/flatcar-linux/mantle/kola/register"
+)
+
+func init() {
+	register.Register(&register.Test{
+		Name:        "cl.misc.gce.oem",
+		ClusterSize: 1,
+		Platforms:   []string{"gce"},
+		Distros:     []string{"cl"},
+		Run:         gceVerifyOEMService,
+	})
+}
+
+func gceVerifyOEMService(c cluster.TestCluster) {
+	machine := c.Machines()[0]
+	// verify that the oem-gce service is running
+	c.MustSSH(machine, "systemctl is-active oem-gce.service")
+	nrestarts := c.MustSSH(machine, "systemctl show oem-gce.service -P NRestarts")
+	if string(nrestarts) != "0" {
+		c.Fatalf("oem-gce service restarted too many times: %s", nrestarts)
+	}
+	// check that interface is configured and named correctly
+	c.MustSSH(machine, "networkctl status eth0")
+}


### PR DESCRIPTION
Add testcase for oem-gce.service on GCP. This test case is currently failing but will pass once https://github.com/flatcar-linux/coreos-overlay/pull/1813 is merged.
