### PR TITLE
kola: find dir of executable if started as "kola"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,6 @@ RUN cd /usr/src/mantle && ./build
 FROM docker.io/library/debian:11
 RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -y qemu-utils qemu-system-x86 qemu-system-aarch64 qemu-efi-aarch64 seabios ovmf lbzip2 sudo dnsmasq gnupg2 git curl iptables nftables dns-root-data ca-certificates sqlite3
 COPY --from=builder /usr/src/mantle/bin /usr/local/bin
-RUN printf '#!/bin/sh\n# Workaround for kola to find its kolet binaries, this script is stored in sbin to get precedence\nexec /usr/local/bin/kola "$@"\n' > /usr/local/sbin/kola
-RUN chmod +x /usr/local/sbin/kola
 RUN ln -s /usr/share/seabios/bios-256k.bin /usr/share/qemu/bios-256k.bin
 
 # For KVM to work, run the resulting container as: docker run --privileged --net host -v /dev:/dev --rm -it TAG

--- a/kola/harness.go
+++ b/kola/harness.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -588,12 +589,27 @@ func boardToArch(board string) string {
 	return strings.SplitN(board, "-", 2)[0]
 }
 
+func findExecDir() string {
+	p, err := os.Executable()
+	if err != nil {
+		if strings.Contains(os.Args[0], "/") {
+			p = os.Args[0]
+		} else {
+			p, err = exec.LookPath(os.Args[0])
+			if err != nil {
+				p = os.Args[0]
+			}
+		}
+	}
+	return filepath.Dir(p)
+}
+
 // scpKolet searches for a kolet binary and copies it to the machine.
 func scpKolet(c cluster.TestCluster, mArch string) {
 	for _, d := range []string{
 		".",
-		filepath.Dir(os.Args[0]),
-		filepath.Join(filepath.Dir(os.Args[0]), mArch),
+		findExecDir(),
+		filepath.Join(findExecDir(), mArch),
 		filepath.Join("/usr/lib/kola", mArch),
 	} {
 		kolet := filepath.Join(d, "kolet")


### PR DESCRIPTION
The logic to find the kolet binaries besides the kola binary only
worked when a relative or absolute path was used to invoke the kola
binary (argument 0).
Support running kola by finding it in the PATH where "kola" would be
the value of argument 0.


## How to use

## Testing done

local test:
`PATH=$PATH:$HOME/kinvolk/mantle/bin kola run -d --platform=qemu-unpriv --qemu-image=/var/tmp/flatcar_production_image.bin cl.basic`
works now, didn't work before