### PR TITLE
Dockerfile: add gsutil for image upload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN cd /usr/src/mantle && ./build
 
 FROM docker.io/library/debian:11
 RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -y qemu-utils qemu-system-x86 qemu-system-aarch64 qemu-efi-aarch64 seabios ovmf lbzip2 sudo dnsmasq gnupg2 git curl iptables nftables dns-root-data ca-certificates sqlite3
+# from https://cloud.google.com/storage/docs/gsutil_install#deb
+RUN echo "deb http://packages.cloud.google.com/apt cloud-sdk main" > /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg > /etc/apt/trusted.gpg.d/cloud.google.gpg && apt-get update -y && apt-get install --no-install-recommends -y python && apt-get install -y google-cloud-cli
 COPY --from=builder /usr/src/mantle/bin /usr/local/bin
 RUN ln -s /usr/share/seabios/bios-256k.bin /usr/share/qemu/bios-256k.bin
 


### PR DESCRIPTION
While ore can be used to create a GCE image, it assumes the image file
already is in a GCS bucket.
Add gsutil to the mantle container image to upload an image file to GCS
for consumption by ore.


## How to use


## Testing done

Done [here](http://192.168.42.7:8080/job/container/job/test/246/console)