### PR TITLE
test/ignition: add `networkd` translation test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Ignition v3 support and tests ([#301](https://github.com/flatcar-linux/mantle/pull/301), [#311](https://github.com/flatcar-linux/mantle/pull/311))
 - Butane config support ([#318](https://github.com/flatcar-linux/mantle/pull/318))
 - GCP: support testing with GVNIC ([#322](https://github.com/flatcar-linux/mantle/pull/322))
+- `networkd` Ignition translation test ([#344](https://github.com/flatcar-linux/mantle/pull/334)) 
 
 ### Changed
 - removed `packet` occurrences in favor of `equinixmetal` ([#277](https://github.com/flatcar-linux/mantle/pull/277))

--- a/kola/tests/ignition/execution.go
+++ b/kola/tests/ignition/execution.go
@@ -81,8 +81,8 @@ func init() {
 		Distros: []string{"cl", "fcos", "rhcos"},
 	})
 	register.Register(&register.Test{
-		Name:        "cl.ignition.links",
-		Run:         testLink,
+		Name:        "cl.ignition.translation",
+		Run:         testTranslation,
 		ClusterSize: 1,
 		// Important: the link's path shares a prefix with the
 		// file's path and should pass the ign-converter sanity
@@ -130,7 +130,7 @@ func runsOnce(c cluster.TestCluster) {
 	c.MustSSH(m, "test ! -e /etc/ignition-ran")
 }
 
-func testLink(c cluster.TestCluster) {
+func testTranslation(c cluster.TestCluster) {
 	m := c.Machines()[0]
 
 	// fail if link is broken or does not exist


### PR DESCRIPTION
In this PR, we add a new test to ensure `networkd` Ignition from spec 2.x is correctly translated to `files` from spec 3.x and applied correctly.

This has been tested with current stable (where `networkd` is still supported) and with https://github.com/flatcar-linux/coreos-overlay/pull/1910

Related to: https://github.com/flatcar-linux/Flatcar/issues/741

:warning: this should be merged _after_ the coreos-overlay's PR merged, backported to alpha/beta and released - otherwise test will fail (except on stable where we still on ignition 2.x so `networkd` is still supported)  