### PR TITLE
kola/test: add kubernetes 1.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - GCP: support testing with GVNIC ([#322](https://github.com/flatcar-linux/mantle/pull/322))
 - `networkd` Ignition translation test ([#344](https://github.com/flatcar-linux/mantle/pull/334)) 
 - kola test `cl.misc.falco` that tests falco kmod building ([#339](https://github.com/flatcar-linux/mantle/pull/339))
+- Kubernetes test for release 1.24.1 ([#337](https://github.com/flatcar-linux/mantle/pull/337))
 
 ### Changed
 - removed `packet` occurrences in favor of `equinixmetal` ([#277](https://github.com/flatcar-linux/mantle/pull/277))
@@ -35,6 +36,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Removed
 - Remove `--repo-branch` option from cork ([#283](https://github.com/flatcar-linux/mantle/pull/283))
+- Removed Kubernetes test for release 1.21.10 ([#337](https://github.com/flatcar-linux/mantle/pull/337))
+- Removed enforced SELinux for `kubeadm.flannel.*` tests ([#337](https://github.com/flatcar-linux/mantle/pull/337))
 
 ## [0.18.0] - 12/01/2022
 ### Security

--- a/kola/tests/kubeadm/kubeadm.go
+++ b/kola/tests/kubeadm/kubeadm.go
@@ -138,6 +138,7 @@ func init() {
 	registerTests := func(config map[string]map[string]interface{}) {
 		for version, params := range config {
 			for _, CNI := range CNIs {
+				flags := []register.Flag{}
 				// ugly but required to remove the reference between params and the params
 				// actually used by the test.
 				testParams := make(map[string]interface{})
@@ -154,6 +155,10 @@ func init() {
 					major = 3140
 				}
 
+				if CNI == "flannel" {
+					flags = append(flags, register.NoEnableSelinux)
+				}
+
 				register.Register(&register.Test{
 					Name:    fmt.Sprintf("kubeadm.%s.%s%s.base", version, CNI, cgroupSuffix),
 					Distros: []string{"cl"},
@@ -163,6 +168,7 @@ func init() {
 						kubeadmBaseTest(c, testParams)
 					},
 					MinVersion: semver.Version{Major: major},
+					Flags:      flags,
 				})
 			}
 		}

--- a/kola/tests/kubeadm/kubeadm.go
+++ b/kola/tests/kubeadm/kubeadm.go
@@ -44,6 +44,31 @@ var (
 	// testConfig holds params for various kubernetes releases
 	// and the nested params are used to render script templates
 	testConfig = map[string]map[string]interface{}{
+		"v1.24.1": map[string]interface{}{
+			"FlannelVersion":   "v0.18.1",
+			"CiliumVersion":    "1.11.5",
+			"CiliumCLIVersion": "v0.10.7",
+			"CNIVersion":       "v1.1.1",
+			"CRIctlVersion":    "v1.24.2",
+			"ReleaseVersion":   "v0.13.0",
+			"DownloadDir":      "/opt/bin",
+			"PodSubnet":        "192.168.0.0/17",
+			"arm64": map[string]string{
+				"KubeadmSum": "171ad33a0ffed8ae0bc78a48b12bd1575a03e221de4ca079e60d46689373c298a95bc95a156ea235f5e4f6c4fe714740277ee57e8f0f267b2eeb77f569039ad9",
+				"KubeletSum": "f774044d65ebcf07143fb482fbe69c8836287d862c740c9e4804c92060d17867f77625fef0c1a0d2a358745520f5e67bd41b7fcf68756ab105ced9e26c84c881",
+				"CRIctlSum":  "ebd055e9b2888624d006decd582db742131ed815d059d529ba21eaf864becca98a84b20a10eec91051b9d837c6855d28d5042bf5e9a454f4540aec6b82d37e96",
+				"CNISum":     "6b5df61a53601926e4b5a9174828123d555f592165439f541bc117c68781f41c8bd30dccd52367e406d104df849bcbcfb72d9c4bafda4b045c59ce95d0ca0742",
+				"KubectlSum": "ae4e316e1127b7189cdd08980729dea0e20946431c8caec07f79ea43dc34e4f161bb687c5cdf306fb032e6a3537597b9d31cfa416ad0bfc85abd0c0f8d11c66d",
+			},
+			"amd64": map[string]string{
+				"KubeadmSum": "4a825ba96997bca7fc1b3a2a4867026632cf3298709685270333452b5d755176c4891c1cfdd589e162d8af0b43aaf956c71455e4cf886ff0d767196eadb9766e",
+				"KubeletSum": "553695adcd0229f680f9edf6afcbbeefc051c77fba6c8ff82644852877c15d422801b5453a09e2fb7ddb4894c713dfe4755562711c302800f985a457a0cbb7c3",
+				"CRIctlSum":  "961188117863ca9af5b084e84691e372efee93ad09daf6a0422e8d75a5803f394d8968064f7ca89f14e8973766201e731241f32538cf2c8d91f0233e786302df",
+				"CNISum":     "4d0ed0abb5951b9cf83cba938ef84bdc5b681f4ac869da8143974f6a53a3ff30c666389fa462b9d14d30af09bf03f6cdf77598c572f8fb3ea00cecdda467a48d",
+				"KubectlSum": "db7e24076f2cbc5bae9033c736048a87c820757af3473cbe583ef7831ad046a9ceeb9e40325e381d193f37ac28f4d6926c8e2fb36ff6029f661b090d8aa15470",
+			},
+			"cgroupv1": false,
+		},
 		"v1.23.4": map[string]interface{}{
 			"FlannelVersion":   "v0.16.3",
 			"CiliumVersion":    "1.11.0",

--- a/kola/tests/kubeadm/kubeadm.go
+++ b/kola/tests/kubeadm/kubeadm.go
@@ -159,6 +159,10 @@ func init() {
 					flags = append(flags, register.NoEnableSelinux)
 				}
 
+				if version == "1.24.1" {
+					major = 3277
+				}
+
 				register.Register(&register.Test{
 					Name:    fmt.Sprintf("kubeadm.%s.%s%s.base", version, CNI, cgroupSuffix),
 					Distros: []string{"cl"},

--- a/kola/tests/kubeadm/kubeadm.go
+++ b/kola/tests/kubeadm/kubeadm.go
@@ -129,11 +129,11 @@ etcd:
 
 func init() {
 	testConfigCgroupV1 := map[string]map[string]interface{}{}
-	testConfigCgroupV1["v1.21.10"] = map[string]interface{}{}
-	for k, v := range testConfig["v1.21.10"] {
-		testConfigCgroupV1["v1.21.10"][k] = v
+	testConfigCgroupV1["v1.22.7"] = map[string]interface{}{}
+	for k, v := range testConfig["v1.22.7"] {
+		testConfigCgroupV1["v1.22.7"][k] = v
 	}
-	testConfigCgroupV1["v1.21.10"]["cgroupv1"] = true
+	testConfigCgroupV1["v1.22.7"]["cgroupv1"] = true
 
 	registerTests := func(config map[string]map[string]interface{}) {
 		for version, params := range config {

--- a/kola/tests/kubeadm/kubeadm.go
+++ b/kola/tests/kubeadm/kubeadm.go
@@ -94,31 +94,6 @@ var (
 			},
 			"cgroupv1": false,
 		},
-		"v1.21.10": map[string]interface{}{
-			"FlannelVersion":   "v0.16.3",
-			"CiliumVersion":    "1.11.0",
-			"CiliumCLIVersion": "v0.10.2",
-			"CNIVersion":       "v1.0.1",
-			"CRIctlVersion":    "v1.22.0",
-			"ReleaseVersion":   "v0.4.0",
-			"DownloadDir":      "/opt/bin",
-			"PodSubnet":        "192.168.0.0/17",
-			"arm64": map[string]string{
-				"KubeadmSum": "9acabdb85f4dada74dab909b6b21315c81fdeba6df2c156bbebf4b18b8d427a114a853e694d1b42c01c12ede23a43e04651292d65917f405486d8b0088fb2b46",
-				"KubeletSum": "029e81f48efa98cbb35835c208540acd662fa16dabea687aff3d25208d7bfa77500d97ed0a756f926f06b989f22971e91baf124d1df330eab9dee90448192752",
-				"CRIctlSum":  "f926c645e0d5f177c0589b1d052ffef4b4ed9d45b3d5b467473b6075ef767fb43b1f7ba5b525d57f021b6b8dc18d7efd27e03e1ec5b71a20f4e321c32456cdd9",
-				"CNISum":     "616c4f493a560ecd1ecc60f758720bb2c3539c4261a63d2094f474380d59d88444637cee7fed124c53193f08de7feb65510fe95579b12306c112ad45a74e1536",
-				"KubectlSum": "c9cd8ebd472d9d6652a307ae78c0753cd3bfbbdcb1ed137db06e16ad900ae454f1e2654d7c01db737b0e2dff3e07b4e18c911264afc94b584f8795baf4a92735",
-			},
-			"amd64": map[string]string{
-				"KubeadmSum": "1319e29679f1d91faf4c9900662641614fd05101dc38618ce075c6819eb8af5a097f8cf416bdf9e2ee9bb92b6c4e3cf4d25df8de2ed6c50ef48a2da605e610b6",
-				"KubeletSum": "ee16a40f5982fe459c919d396f7b407e358394cb27836cba8545a5841b3dcedf02ed4da45207b8e311a0707defe977bdcebbed130c7fefc6dd770ec3afd68718",
-				"CRIctlSum":  "9ff93e9c15942c39c85dd4e8182b3e9cd47fcb15b1315b0fdfd0d73442a84111e6cf8bb74b586e34b1f382a71107eb7e7820544a98d2224ca6b6dee3ee576222",
-				"CNISum":     "220ee0073e9b3708b8ec6159a6ee511b2fd9b88cbe74d48a9b823542e17acf53acec6215869a1d21826422d655eebdd53795fafcef70205d34bf9d8878b493d8",
-				"KubectlSum": "5334a634ea72358f2ec303e82678160e260b8920aeb62c1953a43cb70bc919870568e67144f78c4949e0db1297ee2b5e604ff76a7433637c093919c855d189d1",
-			},
-			"cgroupv1": false,
-		},
 	}
 	plog       = capnslog.NewPackageLogger("github.com/flatcar-linux/mantle", "kola/tests/kubeadm")
 	etcdConfig = conf.ContainerLinuxConfig(`


### PR DESCRIPTION
In this PR, we remove the tests for Kubernetes 1.21.10 and we provide a new test for Kubernetes 1.24.1.

## Testing done

In progress: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/5816/cldsv/

## Note for reviewers

Still need to decide if we want to exclude kubernetes 1.24.1 from being tested on version != from next major.

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
