### PR TITLE
kola/tests: Ignore the testcase to test oem-gce for LTS-2021 releases

### DIFF
--- a/kola/tests/misc/gcp.go
+++ b/kola/tests/misc/gcp.go
@@ -3,6 +3,7 @@
 package misc
 
 import (
+	"github.com/coreos/go-semver/semver"
 	"github.com/flatcar-linux/mantle/kola/cluster"
 	"github.com/flatcar-linux/mantle/kola/register"
 )
@@ -13,6 +14,7 @@ func init() {
 		ClusterSize: 1,
 		Platforms:   []string{"gce"},
 		Distros:     []string{"cl"},
+		MinVersion:  semver.Version{Major: 2801},
 		Run:         gceVerifyOEMService,
 	})
 }


### PR DESCRIPTION
LTS-2021 shipped hardcoded interface name ens4v1 name for GCE, whereas
the tests checks for eth0 hence fails

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
