### PR TITLE
kola: add test that checks that falco module can be built and loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Butane config support ([#318](https://github.com/flatcar-linux/mantle/pull/318))
 - GCP: support testing with GVNIC ([#322](https://github.com/flatcar-linux/mantle/pull/322))
 - `networkd` Ignition translation test ([#344](https://github.com/flatcar-linux/mantle/pull/334)) 
+- kola test `cl.misc.falco` that tests falco kmod building ([#339](https://github.com/flatcar-linux/mantle/pull/339))
 
 ### Changed
 - removed `packet` occurrences in favor of `equinixmetal` ([#277](https://github.com/flatcar-linux/mantle/pull/277))

--- a/kola/tests/misc/falco.go
+++ b/kola/tests/misc/falco.go
@@ -1,0 +1,27 @@
+package misc
+
+import (
+	"github.com/flatcar-linux/mantle/kola/cluster"
+	"github.com/flatcar-linux/mantle/kola/register"
+)
+
+func init() {
+	register.Register(&register.Test{
+		Run:         loadFalco,
+		ClusterSize: 1,
+		Name:        "cl.misc.falco",
+		Distros:     []string{"cl"},
+		Platforms:   []string{"qemu"},
+		// selinux blocks insmod from within container
+		Flags: []register.Flag{register.NoEnableSelinux},
+	})
+}
+
+func loadFalco(c cluster.TestCluster) {
+	// load the falco binary
+	// TODO: first supported version will be 0.33.0, but use master tag for now
+	c.MustSSH(c.Machines()[0], "docker run --rm --privileged -v /root/.falco:/root/.falco -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro -v /etc:/host/etc:ro falcosecurity/falco-driver-loader:master")
+	// Build must succeed and falco must be running
+	c.MustSSH(c.Machines()[0], "dmesg | grep falco")
+	c.MustSSH(c.Machines()[0], "lsmod | grep falco")
+}


### PR DESCRIPTION
# add falco module test

This tests uses the master ref of falcosecurity/falco-driver-loader, but can soon be moved to 0.33.0 once that is released. Selinux needs to be disabled because it blocks insmod from within the container.

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done
Test succeeded: http://jenkins.infra.kinvolk.io:8080/job/os/job/kola/job/qemu/553/

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
