### PR TITLE
api/equinixmetal: do not exclusively rely on Google Cloud Storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `networkd` Ignition translation test ([#344](https://github.com/flatcar-linux/mantle/pull/334)) 
 - kola test `cl.misc.falco` that tests falco kmod building ([#339](https://github.com/flatcar-linux/mantle/pull/339))
 - Kubernetes test for release 1.24.1 ([#337](https://github.com/flatcar-linux/mantle/pull/337))
+- Added storage abstraction for Equinix Metal tests (SSH can be used in addition of Google Cloud Storage) ([#340](https://github.com/flatcar-linux/mantle/pull/340))
 
 ### Changed
 - removed `packet` occurrences in favor of `equinixmetal` ([#277](https://github.com/flatcar-linux/mantle/pull/277))

--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -197,8 +197,11 @@ func init() {
 	sv(&kola.EquinixMetalOptions.InstallerImageKernelURL, "equinixmetal-installer-image-kernel-url", "", "EquinixMetal installer image kernel URL, (default equinixmetal-installer-image-base-url/flatcar_production_pxe.vmlinuz)")
 	sv(&kola.EquinixMetalOptions.InstallerImageCpioURL, "equinixmetal-installer-image-cpio-url", "", "EquinixMetal installer image cpio URL, (default equinixmetal-installer-image-base-url/flatcar_production_pxe_image.cpio.gz)")
 	sv(&kola.EquinixMetalOptions.ImageURL, "equinixmetal-image-url", "", "EquinixMetal image URL (default board-dependent, e.g. \"https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_packet_image.bin.bz2\")")
-	sv(&kola.EquinixMetalOptions.StorageURL, "equinixmetal-storage-url", "gs://users.developer.core-os.net/"+os.Getenv("USER")+"/mantle", "Google Storage base URL for temporary uploads")
+	sv(&kola.EquinixMetalOptions.StorageURL, "equinixmetal-storage-url", "gs://users.developer.core-os.net/"+os.Getenv("USER")+"/mantle", "Storage URL for temporary uploads (supported: gs, ssh+http, ssh+https or ssh which defaults to https for download)")
 	sv(&kola.EquinixMetalOptions.Metro, "equinixmetal-metro", "", "the Metro where you want your server to live")
+	sv(&kola.EquinixMetalOptions.RemoteUser, "equinixmetal-remote-user", "core", "the user for SSH connection to the remote storage")
+	sv(&kola.EquinixMetalOptions.RemoteSSHPrivateKeyPath, "equinixmetal-remote-ssh-private-key-path", "./id_rsa", "the path to SSH private key for SSH connection to the remote storage")
+	sv(&kola.EquinixMetalOptions.RemoteDocumentRoot, "equinixmetal-remote-document-root", "/var/www", "the absolute path to the document root of the webserver for serving temporary files")
 
 	// QEMU-specific options
 	sv(&kola.QEMUOptions.Board, "board", defaultTargetBoard, "target board")

--- a/platform/api/equinixmetal/api.go
+++ b/platform/api/equinixmetal/api.go
@@ -274,12 +274,16 @@ func (a *API) CreateOrUpdateDevice(hostname string, conf *conf.Conf, console Con
 	}
 	defer a.storage.Delete(context.TODO(), userdataName)
 
+	plog.Debugf("user-data available at %s", userdataURL)
+
 	// This can't go in userdata because the installed coreos-cloudinit will try to execute it.
 	ipxeScriptName, ipxeScriptURL, err := a.uploadObject(hostname, "application/octet-stream", []byte(a.ipxeScript(userdataURL)))
 	if err != nil {
 		return nil, err
 	}
 	defer a.storage.Delete(context.TODO(), ipxeScriptName)
+
+	plog.Debugf("iPXE script available at %s", ipxeScriptURL)
 
 	device, err := a.createDevice(hostname, ipxeScriptURL, id)
 	if err != nil {

--- a/platform/api/equinixmetal/api.go
+++ b/platform/api/equinixmetal/api.go
@@ -21,7 +21,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net"
+	"net/url"
 	"strings"
 	"time"
 
@@ -30,13 +32,15 @@ import (
 	"github.com/packethost/packngo"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/net/context"
-	gs "google.golang.org/api/storage/v1"
 
 	"github.com/flatcar-linux/mantle/auth"
 	"github.com/flatcar-linux/mantle/platform"
+	"github.com/flatcar-linux/mantle/platform/api/equinixmetal/storage"
+	"github.com/flatcar-linux/mantle/platform/api/equinixmetal/storage/gcs"
+	"github.com/flatcar-linux/mantle/platform/api/equinixmetal/storage/sshstorage"
 	"github.com/flatcar-linux/mantle/platform/api/gcloud"
 	"github.com/flatcar-linux/mantle/platform/conf"
-	"github.com/flatcar-linux/mantle/storage"
+	ms "github.com/flatcar-linux/mantle/storage"
 	"github.com/flatcar-linux/mantle/util"
 )
 
@@ -103,12 +107,23 @@ type Options struct {
 	StorageURL string
 	// Metro is where you want your server to live.
 	Metro string
+
+	// RemoteOptions for remote storage
+
+	// RemoteUser is the user for the SSH connection.
+	RemoteUser string
+
+	// RemoteSSHPrivateKeyPath is the private SSH key path used for the SSH authentication.
+	RemoteSSHPrivateKeyPath string
+
+	// RemoteDocumentRoot is the path served by the webserver.
+	RemoteDocumentRoot string
 }
 
 type API struct {
-	c      *packngo.Client
-	bucket *storage.Bucket
-	opts   *Options
+	c       *packngo.Client
+	storage storage.Storage
+	opts    *Options
 }
 
 type Console interface {
@@ -158,21 +173,74 @@ func New(opts *Options) (*API, error) {
 		opts.ImageURL = defaultImageURL[opts.Board]
 	}
 
-	gapi, err := gcloud.New(opts.GSOptions)
+	url, err := url.Parse(opts.StorageURL)
 	if err != nil {
-		return nil, fmt.Errorf("connecting to Google Storage: %v", err)
+		return nil, fmt.Errorf("parsing storage URL: %w", err)
 	}
-	bucket, err := storage.NewBucket(gapi.Client(), opts.StorageURL)
-	if err != nil {
-		return nil, fmt.Errorf("connecting to Google Storage bucket: %v", err)
+
+	var storage storage.Storage
+
+	switch url.Scheme {
+	case "gs":
+		gapi, err := gcloud.New(opts.GSOptions)
+		if err != nil {
+			return nil, fmt.Errorf("connecting to Google Storage: %w", err)
+		}
+
+		bucket, err := ms.NewBucket(gapi.Client(), opts.StorageURL)
+		if err != nil {
+			return nil, fmt.Errorf("connecting to Google Storage bucket: %w", err)
+		}
+
+		storage = gcs.New(bucket)
+	case "ssh+http", "ssh+https", "ssh":
+		key, err := ioutil.ReadFile(opts.RemoteSSHPrivateKeyPath)
+		if err != nil {
+			return nil, fmt.Errorf("reading private key: %w", err)
+		}
+
+		signer, err := ssh.ParsePrivateKey(key)
+		if err != nil {
+			return nil, fmt.Errorf("parsing private key: %w", err)
+		}
+
+		cfg := &ssh.ClientConfig{
+			User: opts.RemoteUser,
+			// this is only used for testing - it's ok to live with that.
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+			Auth: []ssh.AuthMethod{
+				ssh.PublicKeys(signer),
+			},
+		}
+
+		client, err := ssh.Dial("tcp", url.Host, cfg)
+		if err != nil {
+			return nil, fmt.Errorf("creating SSH client: %w", err)
+		}
+
+		// default webserver protocol is HTTPs
+		protocol := "https"
+
+		// we try to extract the procol from the URL scheme of the
+		// storage URL (ssh+http, ssh+https, etc.)
+		protocols := strings.SplitN(url.Scheme, "+", 2)
+		for _, proto := range protocols {
+			if proto == "ssh" {
+				continue
+			}
+
+			protocol = proto
+		}
+
+		storage = sshstorage.New(client, url.Hostname(), opts.RemoteDocumentRoot, protocol)
 	}
 
 	client := packngo.NewClientWithAuth("github.com/flatcar-linux/mantle", opts.ApiKey, nil)
 
 	return &API{
-		c:      client,
-		bucket: bucket,
-		opts:   opts,
+		c:       client,
+		storage: storage,
+		opts:    opts,
 	}, nil
 }
 
@@ -204,14 +272,14 @@ func (a *API) CreateOrUpdateDevice(hostname string, conf *conf.Conf, console Con
 	if err != nil {
 		return nil, err
 	}
-	defer a.bucket.Delete(context.TODO(), userdataName)
+	defer a.storage.Delete(context.TODO(), userdataName)
 
 	// This can't go in userdata because the installed coreos-cloudinit will try to execute it.
 	ipxeScriptName, ipxeScriptURL, err := a.uploadObject(hostname, "application/octet-stream", []byte(a.ipxeScript(userdataURL)))
 	if err != nil {
 		return nil, err
 	}
-	defer a.bucket.Delete(context.TODO(), ipxeScriptName)
+	defer a.storage.Delete(context.TODO(), ipxeScriptName)
 
 	device, err := a.createDevice(hostname, ipxeScriptURL, id)
 	if err != nil {
@@ -468,17 +536,12 @@ func (a *API) uploadObject(hostname, contentType string, data []byte) (string, s
 	rand.Read(b)
 	name := fmt.Sprintf("%s-%x", hostname, b)
 
-	obj := gs.Object{
-		Name:        a.bucket.Prefix() + name,
-		ContentType: contentType,
-	}
-	err := a.bucket.Upload(context.TODO(), &obj, bytes.NewReader(data))
+	name, URL, err := a.storage.Upload(name, contentType, data)
 	if err != nil {
-		return "", "", fmt.Errorf("uploading object: %v", err)
+		return "", "", fmt.Errorf("uploading content: %w", err)
 	}
 
-	url := fmt.Sprintf("https://bucket.release.flatcar-linux.net/%v/%v", a.bucket.Name(), obj.Name)
-	return obj.Name, url, nil
+	return name, URL, nil
 }
 
 func (a *API) ipxeScript(userdataURL string) string {

--- a/platform/api/equinixmetal/api.go
+++ b/platform/api/equinixmetal/api.go
@@ -252,6 +252,11 @@ func (a *API) PreflightCheck() error {
 	return nil
 }
 
+// Close takes care of closing existing connections.
+func (a *API) Close() error {
+	return a.storage.Close()
+}
+
 // console is optional, and is closed on error or when the device is deleted.
 func (a *API) CreateOrUpdateDevice(hostname string, conf *conf.Conf, console Console, id string) (*packngo.Device, error) {
 	consoleStarted := false

--- a/platform/api/equinixmetal/storage/gcs/gcs.go
+++ b/platform/api/equinixmetal/storage/gcs/gcs.go
@@ -1,0 +1,47 @@
+// Copyright The Mantle Authors.
+// SPDX-License-Identifier: Apache-2.0
+package gcs
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	gs "google.golang.org/api/storage/v1"
+
+	"github.com/flatcar-linux/mantle/platform/api/equinixmetal/storage"
+	ms "github.com/flatcar-linux/mantle/storage"
+)
+
+func New(bucket *ms.Bucket) storage.Storage {
+	return &GCS{
+		bucket: bucket,
+	}
+}
+
+// GCS implements a Storage interface for Google Cloud Storage.
+type GCS struct {
+	bucket *ms.Bucket
+}
+
+// Upload the []byte data to Google Cloud Storage bucket.
+func (g *GCS) Upload(name, contentType string, data []byte) (string, string, error) {
+	obj := gs.Object{
+		Name:        g.bucket.Prefix() + name,
+		ContentType: contentType,
+	}
+	err := g.bucket.Upload(context.TODO(), &obj, bytes.NewReader(data))
+	if err != nil {
+		return "", "", fmt.Errorf("uploading object: %v", err)
+	}
+
+	url := fmt.Sprintf("https://bucket.release.flatcar-linux.net/%v/%v", g.bucket.Name(), obj.Name)
+	return obj.Name, url, nil
+}
+
+// Delete the uploaded data from Google Cloud Storage bucket.
+func (g *GCS) Delete(ctx context.Context, name string) error {
+	return g.bucket.Delete(ctx, name)
+}
+
+func (g *GCS) Close() error { return nil }

--- a/platform/api/equinixmetal/storage/sshstorage/sshstorage.go
+++ b/platform/api/equinixmetal/storage/sshstorage/sshstorage.go
@@ -1,0 +1,98 @@
+// Copyright The Mantle Authors.
+// SPDX-License-Identifier: Apache-2.0
+package sshstorage
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/flatcar-linux/mantle/platform/api/equinixmetal/storage"
+
+	"github.com/coreos/pkg/capnslog"
+	"golang.org/x/crypto/ssh"
+)
+
+var (
+	plog = capnslog.NewPackageLogger("github.com/flatcar-linux/mantle", "platform/api/equinixmetal/storage/remote")
+)
+
+func New(client *ssh.Client, host, docRoot, protocol string) storage.Storage {
+	return &Remote{
+		client:   client,
+		host:     host,
+		docRoot:  docRoot,
+		protocol: protocol,
+	}
+}
+
+// Remote implements a Storage interface for remote server.
+type Remote struct {
+	client *ssh.Client
+
+	// host for SSH connection and webserver
+	host string
+
+	// docRoot is the absolute path to the webserver document root (e.g /var/wwww)
+	docRoot string
+
+	// procol is the procol (http or https) for accessing the uploaded content
+	protocol string
+}
+
+func (r *Remote) Upload(name, contentType string, data []byte) (string, string, error) {
+	session, err := r.client.NewSession()
+	if err != nil {
+		return "", "", fmt.Errorf("creating SSH session: %w", err)
+	}
+	defer session.Close()
+
+	// we define the file extension based on the contentType
+	ext := "ign"
+	if contentType == "application/octet-stream" {
+		ext = "ipxe"
+	}
+
+	fName := fmt.Sprintf("mantle-%s.%s", name, ext)
+
+	p := fmt.Sprintf("%s/%s", r.docRoot, fName)
+
+	session.Stdin = bytes.NewReader(data)
+
+	if err := session.Run(fmt.Sprintf("/bin/cat - > %s", p)); err != nil {
+		return "", "", fmt.Errorf("writing data from standard input: %w", err)
+	}
+
+	plog.Debugf("%s uploaded to %s", fName, p)
+
+	return p, fmt.Sprintf("%s://%s/%s", r.protocol, r.host, fName), nil
+}
+
+// Delete the uploaded data from remote storage.
+func (r *Remote) Delete(ctx context.Context, name string) error {
+	session, err := r.client.NewSession()
+	if err != nil {
+		return fmt.Errorf("creating SSH session: %w", err)
+	}
+	defer session.Close()
+
+	if err := session.Run(fmt.Sprintf("/bin/rm --force %s", name)); err != nil {
+		return fmt.Errorf("removing data from SSH session: %w", err)
+	}
+
+	plog.Debugf("%s deleted from remote storage", name)
+
+	return nil
+}
+
+func (r *Remote) Close() error {
+	if r.client != nil {
+		if err := r.client.Close(); err != nil {
+			return fmt.Errorf("closing SSH client: %w", err)
+		}
+
+		return nil
+	}
+
+	return nil
+}

--- a/platform/api/equinixmetal/storage/storage.go
+++ b/platform/api/equinixmetal/storage/storage.go
@@ -1,0 +1,20 @@
+// Copyright The Mantle Authors.
+// SPDX-License-Identifier: Apache-2.0
+package storage
+
+import "context"
+
+// Storage defines a medium used to store the data temporary
+// created for a test.
+type Storage interface {
+	// Upload the []byte data to the implemented storage under the given name.
+	// The contentType is used by the underlying implementation to store and distribute the data
+	// in the right format.
+	Upload(name, contentType string, data []byte) (string, string, error)
+
+	// Delete the data associated to the name.
+	Delete(ctx context.Context, name string) error
+
+	// Close terminates eventual opened connections.
+	Close() error
+}

--- a/platform/machine/equinixmetal/flight.go
+++ b/platform/machine/equinixmetal/flight.go
@@ -92,6 +92,12 @@ func (pf *flight) NewCluster(rconf *platform.RuntimeConfig) (platform.Cluster, e
 }
 
 func (pf *flight) Destroy() {
+	if pf.api != nil {
+		if err := pf.api.Close(); err != nil {
+			plog.Errorf("closing API %v: ", err)
+		}
+	}
+
 	if pf.sshKeyID != "" {
 		if err := pf.api.DeleteKey(pf.sshKeyID); err != nil {
 			plog.Errorf("Error deleting key %v: %v", pf.sshKeyID, err)


### PR DESCRIPTION
In this PR, we abstract the temporary storage used by Equinix Metal tests and we bring the possibility to implement another ones (like SSH).

Related to: https://github.com/flatcar-linux/Flatcar/issues/720

## How to use

```bash
./kola run --platform=equinixmetal ... --equinixmetal-storage-url="ssh+https://my-server"
``` 

## Testing done
(Voluntary obfuscated the server name) 
```
=== RUN   bpf.execsnoop
2022-06-24T09:09:18Z platform/api/equinixmetal/storage/remote: mantle-tormath1-k124-33001fe726-02888b3dd2.ign uploaded to /home/core/content/mantle-tormath1-k124-33001fe726-02888b3dd2.ign
2022-06-24T09:09:18Z platform/api/equinixmetal: user-data available at http://my-server/mantle-tormath1-k124-33001fe726-02888b3dd2.ign
2022-06-24T09:09:18Z platform/api/equinixmetal/storage/remote: mantle-tormath1-k124-33001fe726-fa062834f0.ipxe uploaded to /home/core/content/mantle-tormath1-k124-33001fe726-fa062834f0.ipxe
2022-06-24T09:09:18Z platform/api/equinixmetal: iPXE script available at http://my-server/mantle-tormath1-k124-33001fe726-fa062834f0.ipxe
2022-06-24T09:09:18Z platform/api/equinixmetal: Recycling is not possible, creating a new instance
2022-06-24T09:09:25Z platform/api/equinixmetal: Created device: "43034ffb-29e5-4745-ba2c-c2da49877654"
2022-06-24T09:14:35Z platform/api/equinixmetal: Device active: "43034ffb-29e5-4745-ba2c-c2da49877654"
2022-06-24T09:15:05Z platform/api/equinixmetal: Finished installation of device: "43034ffb-29e5-4745-ba2c-c2da49877654"
2022-06-24T09:15:05Z platform/api/equinixmetal/storage/remote: /home/core/content/mantle-tormath1-k124-33001fe726-fa062834f0.ipxe deleted from remote storage
2022-06-24T09:15:06Z platform/api/equinixmetal/storage/remote: /home/core/content/mantle-tormath1-k124-33001fe726-02888b3dd2.ign deleted from remote storage
```

Also tested with regular GCS (default behavior)

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
