### PR TITLE
kola/tests/falco: disable test case for arm64

### DIFF
--- a/kola/tests/misc/falco.go
+++ b/kola/tests/misc/falco.go
@@ -12,6 +12,8 @@ func init() {
 		Name:        "cl.misc.falco",
 		Distros:     []string{"cl"},
 		Platforms:   []string{"qemu"},
+		// falco builder container can't handle our arm64 config (yet)
+		Architectures: []string{"amd64"},
 		// selinux blocks insmod from within container
 		Flags: []register.Flag{register.NoEnableSelinux},
 	})


### PR DESCRIPTION
The cl.misc.falco test currently fails for arm64 due to issues with the falco container image.
Disable the test.