### PR TITLE
kola/tests/kubeadm: Test K8s 1.24 with LTS, Stable, and Beta

### DIFF
--- a/kola/tests/kubeadm/kubeadm.go
+++ b/kola/tests/kubeadm/kubeadm.go
@@ -160,7 +160,7 @@ func init() {
 				}
 
 				if version == "1.24.1" {
-					major = 3277
+					major = 3033
 				}
 
 				register.Register(&register.Test{


### PR DESCRIPTION
K8s 1.24 didn't work out of the box and we had to enable containerd
and some kernel modules. This is now backported to all channels and
we should make sure that K8s 1.24 works on all channels.

## How to use


## Testing done

None, either we do it now or merge as is and we let the nightly test it and if we see problems, fix them until the test works.