### PR TITLE
kola/tests: Limit generic tests to QEMU

### DIFF
--- a/kola/tests/bpf/bpf.go
+++ b/kola/tests/bpf/bpf.go
@@ -42,6 +42,8 @@ func init() {
 		Flags: []register.Flag{register.NoEnableSelinux},
 		// exclude `arm64` while `quay.io/iovisor/bcc` does not have `arm64` support.
 		Architectures: []string{"amd64"},
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 }
 

--- a/kola/tests/bpf/local-gadget.go
+++ b/kola/tests/bpf/local-gadget.go
@@ -107,6 +107,8 @@ func init() {
 		// current LTS has DOCKER_API_VERSION=1.40 which is too old for local-gadget docker client.
 		// "client version 1.41 is too new. Maximum supported API version is 1.40"
 		MinVersion: semver.Version{Major: 3033},
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 }
 

--- a/kola/tests/docker/docker.go
+++ b/kola/tests/docker/docker.go
@@ -60,6 +60,8 @@ func init() {
 		Name:        "docker.selinux",
 		Distros:     []string{"cl"},
 		MinVersion:  semver.Version{Major: 2942},
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 	register.Register(&register.Test{
 		Run:         dockerNetwork,
@@ -68,6 +70,7 @@ func init() {
 		Distros:     []string{"cl"},
 		// No idea why Docker containers cannot reach each the other VM
 		ExcludePlatforms: []string{"qemu-unpriv"},
+		// Should run on all cloud environments to check against network conflicts
 	})
 	register.Register(&register.Test{
 		Run:           dockerOldClient,
@@ -77,12 +80,16 @@ func init() {
 		Distros:       []string{"cl"},
 		// incompatible with docker >=20.10
 		EndVersion: semver.Version{Major: 2956},
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 	register.Register(&register.Test{
 		Run:         dockerUserns,
 		ClusterSize: 1,
 		Name:        "docker.userns",
 		Distros:     []string{"cl"},
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 		UserData: conf.ContainerLinuxConfig(`
 systemd:
   units:
@@ -124,12 +131,16 @@ passwd:
 		ClusterSize: 1,
 		Name:        `docker.base`,
 		Distros:     []string{"cl"},
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 
 	register.Register(&register.Test{
 		Run:         func(c cluster.TestCluster) { testDockerInfo("btrfs", c) },
 		ClusterSize: 1,
 		Name:        "docker.btrfs-storage",
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 		// Note: copied verbatim from https://github.com/coreos/docs/blob/master/os/mounting-storage.md#creating-and-mounting-a-btrfs-volume-file
 		UserData: conf.ContainerLinuxConfig(`
 systemd:
@@ -172,6 +183,8 @@ systemd:
 		Run:         dockerBaseTests,
 		ClusterSize: 1,
 		Distros:     []string{"cl"},
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 		UserData: conf.ContainerLinuxConfig(`
 systemd:
   units:
@@ -214,6 +227,8 @@ systemd:
 		Run:         dockerContainerdRestart,
 		ClusterSize: 1,
 		Distros:     []string{"cl"},
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 		UserData: conf.ContainerLinuxConfig(`
 systemd:
   units:

--- a/kola/tests/docker/torcx_manifest_pkgs.go
+++ b/kola/tests/docker/torcx_manifest_pkgs.go
@@ -37,6 +37,8 @@ func init() {
 		// ESX: Currently Ignition does not support static IPs during the initramfs
 		ExcludePlatforms: []string{"esx", "do"},
 		Distros:          []string{"cl"},
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 }
 

--- a/kola/tests/etcd/discovery.go
+++ b/kola/tests/etcd/discovery.go
@@ -40,6 +40,7 @@ func init() {
   initial_advertise_peer_urls: http://{PRIVATE_IPV4}:2380
   discovery:                   $discovery`),
 		Distros: []string{"cl"},
+		// Should run on all cloud environments to test CLC IP addr templating
 	})
 
 	register.Register(&register.Test{
@@ -57,6 +58,8 @@ etcd:
   discovery:                   $discovery
   enable_v2:                   true`),
 		Distros: []string{"cl"},
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 
 	register.Register(&register.Test{
@@ -74,6 +77,8 @@ etcd:
   initial_advertise_peer_urls: http://127.0.0.1:2380
 `, uuid.New())),
 		Distros: []string{"cl"},
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 }
 

--- a/kola/tests/flannel/flannel.go
+++ b/kola/tests/flannel/flannel.go
@@ -71,6 +71,7 @@ func init() {
 		ExcludePlatforms: []string{"qemu-unpriv"},
 		UserData:         flannelConf.Subst("$type", "udp"),
 		Architectures:    []string{"amd64"},
+		// Should run on all cloud environments to check for network problems
 	})
 
 	register.Register(&register.Test{
@@ -79,6 +80,7 @@ func init() {
 		Name:        "cl.flannel.vxlan",
 		Distros:     []string{"cl"},
 		UserData:    flannelConf.Subst("$type", "vxlan"),
+		// Should run on all cloud environments to check for network problems
 	})
 }
 

--- a/kola/tests/ignition/empty.go
+++ b/kola/tests/ignition/empty.go
@@ -32,6 +32,7 @@ func init() {
 		ExcludePlatforms: []string{"qemu", "esx"},
 		Distros:          []string{"cl"},
 		UserData:         conf.Empty(),
+		// Should run on all cloud environments
 	})
 	// Tests for https://github.com/coreos/bugs/issues/1981
 	register.Register(&register.Test{
@@ -42,6 +43,7 @@ func init() {
 		Distros:          []string{"cl"},
 		Flags:            []register.Flag{register.NoSSHKeyInUserData},
 		UserData:         conf.Ignition(`{"ignitionVersion": 1}`),
+		// Should run on all cloud environments
 	})
 	register.Register(&register.Test{
 		Name:             "cl.ignition.v2.noop",
@@ -51,6 +53,7 @@ func init() {
 		Distros:          []string{"cl"},
 		Flags:            []register.Flag{register.NoSSHKeyInUserData},
 		UserData:         conf.Ignition(`{"ignition":{"version":"2.0.0"}}`),
+		// Should run on all cloud environments
 	})
 }
 

--- a/kola/tests/ignition/execution.go
+++ b/kola/tests/ignition/execution.go
@@ -44,6 +44,8 @@ func init() {
                              }
                            }`),
 		Distros: []string{"cl"},
+		// We can run the coreos.ignition.once test on all cloud environments instead
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 	register.Register(&register.Test{
 		Name:        "coreos.ignition.once",

--- a/kola/tests/ignition/filesystem.go
+++ b/kola/tests/ignition/filesystem.go
@@ -79,6 +79,8 @@ func init() {
 		ClusterSize: 1,
 		UserData:    btrfsConfigV1,
 		Distros:     []string{"cl"},
+		// Running only cl.ignition.v2.btrfsroot on all clouds should be enough
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 	register.Register(&register.Test{
 		Name:        "cl.ignition.v2.btrfsroot",
@@ -135,6 +137,8 @@ func init() {
 		ClusterSize: 1,
 		UserData:    xfsConfigV1,
 		Distros:     []string{"cl"},
+		// Running only cl.ignition.v2.btrfsroot on all clouds should be enough
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 	register.Register(&register.Test{
 		Name:        "cl.ignition.v2.xfsroot",
@@ -142,6 +146,8 @@ func init() {
 		ClusterSize: 1,
 		UserData:    xfsConfigV2,
 		Distros:     []string{"cl"},
+		// Running only cl.ignition.v2.btrfsroot on all clouds should be enough
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 
 	// Reformat the root as ext4
@@ -191,6 +197,8 @@ func init() {
 		ClusterSize: 1,
 		UserData:    ext4ConfigV1,
 		Distros:     []string{"cl"},
+		// Running only cl.ignition.v2.btrfsroot on all clouds should be enough
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 	register.Register(&register.Test{
 		Name:        "cl.ignition.v2.ext4root",
@@ -198,12 +206,16 @@ func init() {
 		ClusterSize: 1,
 		UserData:    ext4ConfigV2,
 		Distros:     []string{"cl"},
+		// Running only cl.ignition.v2.btrfsroot on all clouds should be enough
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 	register.Register(&register.Test{
 		Name:        "cl.ignition.v2_1.ext4checkexisting",
 		Run:         ext4CheckExisting,
 		ClusterSize: 1,
 		Distros:     []string{"cl"},
+		// Running only cl.ignition.v2.btrfsroot on all clouds should be enough
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 
 	vfatConfigV2_1 := conf.Ignition(`{
@@ -230,6 +242,8 @@ func init() {
 		ClusterSize: 1,
 		UserData:    vfatConfigV2_1,
 		Distros:     []string{"cl"},
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 
 	swapConfigV2_1 := conf.Ignition(`{
@@ -256,6 +270,8 @@ func init() {
 		ClusterSize: 1,
 		UserData:    swapConfigV2_1,
 		Distros:     []string{"cl"},
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 
 	swapActivation := conf.ContainerLinuxConfig(fmt.Sprintf(`storage:
@@ -302,7 +318,9 @@ systemd:
 		ClusterSize: 1,
 		UserData:    swapActivation,
 		Distros:     []string{"cl"},
-		MinVersion:  semver.Version{Major: 3033},
+		// This test is normally not related to the cloud environment
+		Platforms:  []string{"qemu", "qemu-unpriv"},
+		MinVersion: semver.Version{Major: 3033},
 	})
 }
 

--- a/kola/tests/ignition/kernel.go
+++ b/kola/tests/ignition/kernel.go
@@ -22,7 +22,8 @@ kernel_arguments:
     - quiet`),
 		MinVersion: semver.Version{Major: 3185},
 		// The additional reboot causes a large waiting time
-		// and it's enough to test this on QEMU
+		// and it's enough to test this on QEMU and other clouds
+		// to check that the grub.cfg rewriting causes no problems
 		ExcludePlatforms: []string{"equinixmetal"},
 	})
 }

--- a/kola/tests/ignition/luks.go
+++ b/kola/tests/ignition/luks.go
@@ -16,7 +16,9 @@ func init() {
 		Run:         luksTest,
 		ClusterSize: 1,
 		Distros:     []string{"cl"},
-		MinVersion:  semver.Version{Major: 3185},
+		// This test is normally not related to the cloud environment
+		Platforms:  []string{"qemu", "qemu-unpriv"},
+		MinVersion: semver.Version{Major: 3185},
 		UserData: conf.Butane(`---
 variant: flatcar
 version: 1.0.0

--- a/kola/tests/ignition/oem.go
+++ b/kola/tests/ignition/oem.go
@@ -27,7 +27,9 @@ func init() {
 		Run:         reusePartition,
 		ClusterSize: 1,
 		Distros:     []string{"cl"},
-		MinVersion:  semver.Version{Major: 2983},
+		// This test overwrites the grub.cfg which does not work on cloud environments after reboot
+		Platforms:  []string{"qemu", "qemu-unpriv"},
+		MinVersion: semver.Version{Major: 2983},
 		UserData: conf.ContainerLinuxConfig(`storage:
   filesystems:
      - name: oem
@@ -47,7 +49,9 @@ func init() {
 		Run:         reusePartition,
 		ClusterSize: 1,
 		Distros:     []string{"cl"},
-		MinVersion:  semver.Version{Major: 2983},
+		// This test overwrites the grub.cfg which does not work on cloud environments after reboot
+		Platforms:  []string{"qemu", "qemu-unpriv"},
+		MinVersion: semver.Version{Major: 2983},
 		UserData: conf.ContainerLinuxConfig(`storage:
   filesystems:
      - name: oem

--- a/kola/tests/ignition/passwd.go
+++ b/kola/tests/ignition/passwd.go
@@ -29,6 +29,8 @@ func init() {
 		Name:        "cl.ignition.v1.groups",
 		Run:         groups,
 		ClusterSize: 1,
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 		UserData: conf.Ignition(`{
 		             "ignitionVersion": 1,
 		             "systemd": {
@@ -57,6 +59,8 @@ func init() {
 		Name:        "coreos.ignition.groups",
 		Run:         groups,
 		ClusterSize: 1,
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 		UserData: conf.Ignition(`{
 		             "ignition": { "version": "2.0.0" },
 		             "systemd": {
@@ -107,6 +111,8 @@ func init() {
 		Name:        "cl.ignition.v1.users",
 		Run:         users,
 		ClusterSize: 1,
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 		UserData: conf.Ignition(`{
 		             "ignitionVersion": 1,
 		             "systemd": {
@@ -141,6 +147,8 @@ func init() {
 		Name:        "cl.ignition.v2.users",
 		Run:         users,
 		ClusterSize: 1,
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 		UserData: conf.Ignition(`{
 		             "ignition": { "version": "2.0.0" },
 		             "systemd": {
@@ -175,6 +183,8 @@ func init() {
 		Name:        "coreos.ignition.v2.users",
 		Run:         usersRhcos,
 		ClusterSize: 1,
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 		UserData: conf.Ignition(`{
 		             "ignition": { "version": "2.0.0" },
 		             "passwd": {

--- a/kola/tests/ignition/resource.go
+++ b/kola/tests/ignition/resource.go
@@ -108,6 +108,7 @@ func init() {
 		// ESX: Currently Ignition does not support static IPs during the initramfs
 		ExcludePlatforms: []string{"esx", "do", "qemu-unpriv"},
 		Distros:          []string{"cl", "fcos", "rhcos"},
+		// This should run on all clouds to test initramfs networking
 	})
 	register.Register(&register.Test{
 		Name:        "coreos.ignition.resource.remote",
@@ -116,6 +117,7 @@ func init() {
 		// ESX: Currently Ignition does not support static IPs during the initramfs
 		// https://github.com/coreos/bugs/issues/2205 for DO
 		ExcludePlatforms: []string{"esx", "do"},
+		// This should run on all clouds to test initramfs networking
 		UserData: conf.Ignition(`{
 		  "ignition": {
 		      "version": "2.1.0"
@@ -241,7 +243,9 @@ func init() {
 		// ESX: Currently Ignition does not support static IPs during the initramfs
 		// https://github.com/coreos/bugs/issues/2205 for DO
 		ExcludePlatforms: []string{"esx", "do"},
-		MinVersion:       semver.Version{Major: 1995},
+		// This does not need to run on all clouds because it is a special case of coreos.ignition.resource.remote
+		Platforms:  []string{"qemu", "qemu-unpriv"},
+		MinVersion: semver.Version{Major: 1995},
 		UserData: conf.Ignition(`{
 		  "ignition": {
 		      "version": "2.1.0"

--- a/kola/tests/ignition/sethostname.go
+++ b/kola/tests/ignition/sethostname.go
@@ -87,6 +87,8 @@ func init() {
 		UserData:         configV1,
 		Distros:          []string{"cl"},
 		ExcludePlatforms: []string{"azure"},
+		// It's enough if coreos.ignition.sethostname runs on all clouds
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 	register.Register(&register.Test{
 		Name:             "coreos.ignition.sethostname",
@@ -96,6 +98,7 @@ func init() {
 		UserDataV3:       configV3,
 		Distros:          []string{"cl", "fcos", "rhcos"},
 		ExcludePlatforms: []string{"azure"},
+		// Should run on all clouds to test for conflicts with DHCP hostnames, afterburn or other mechanisms
 	})
 }
 

--- a/kola/tests/ignition/ssh.go
+++ b/kola/tests/ignition/ssh.go
@@ -30,6 +30,8 @@ func init() {
 		Flags:            []register.Flag{register.NoSSHKeyInMetadata},
 		UserData:         conf.Ignition(`{"ignitionVersion": 1}`),
 		Distros:          []string{"cl"},
+		// Does not really need to run in addition to coreos.ignition.ssh.key, so at least limit it to one cloud (here "do")
+		Platforms: []string{"do"},
 	})
 	register.Register(&register.Test{
 		Name:             "coreos.ignition.ssh.key",

--- a/kola/tests/ignition/symlink.go
+++ b/kola/tests/ignition/symlink.go
@@ -15,6 +15,8 @@ func init() {
 		Name:        "cl.ignition.symlink",
 		Run:         writeAbsoluteSymlink,
 		ClusterSize: 1,
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 		UserData: conf.Ignition(`{
 		  "ignition": {
 		      "version": "3.0.0"

--- a/kola/tests/ignition/systemd.go
+++ b/kola/tests/ignition/systemd.go
@@ -24,8 +24,10 @@ import (
 
 func init() {
 	register.Register(&register.Test{
-		Name:        "coreos.ignition.systemd.enable-service",
-		Run:         enableSystemdService,
+		Name: "coreos.ignition.systemd.enable-service",
+		Run:  enableSystemdService,
+		// This test is normally not related to the cloud environment
+		Platforms:   []string{"qemu", "qemu-unpriv"},
 		ClusterSize: 1,
 		// enable nfs-server, touch /etc/exports as it doesn't exist by default on Container Linux,
 		// and touch /var/lib/nfs/etab (https://bugzilla.redhat.com/show_bug.cgi?id=1394395) for RHCOS

--- a/kola/tests/ignition/units.go
+++ b/kola/tests/ignition/units.go
@@ -15,6 +15,8 @@ func init() {
 		Name:        "cl.ignition.instantiated.enable-unit",
 		Run:         enableSystemdInstantiatedService,
 		ClusterSize: 1,
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 		UserData: conf.Ignition(`{
     "ignition": {"version": "3.0.0"},
     "systemd": {

--- a/kola/tests/kubeadm/kubeadm.go
+++ b/kola/tests/kubeadm/kubeadm.go
@@ -168,6 +168,7 @@ func init() {
 					Distros: []string{"cl"},
 					// Network config problems in esx and qemu-unpriv
 					ExcludePlatforms: []string{"esx", "qemu-unpriv"},
+					// This should run on all clouds as a good end-to-end test
 					Run: func(c cluster.TestCluster) {
 						kubeadmBaseTest(c, testParams)
 					},

--- a/kola/tests/locksmith/locksmith.go
+++ b/kola/tests/locksmith/locksmith.go
@@ -37,6 +37,8 @@ func init() {
 		Name:        "cl.locksmith.cluster",
 		Run:         locksmithCluster,
 		ClusterSize: 3,
+		// When cl.etcd-member.discovery runs on all clouds to test CLC IP templating, we can skip running this
+		Platforms: []string{"qemu", "qemu-unpriv"},
 		UserData: conf.ContainerLinuxConfig(`locksmith:
   reboot_strategy: etcd-lock
 etcd:
@@ -53,12 +55,16 @@ etcd:
 		Name:        "coreos.locksmith.reboot",
 		Run:         locksmithReboot,
 		ClusterSize: 1,
-		Distros:     []string{"cl"},
+		// This test is normally not be related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
+		Distros:   []string{"cl"},
 	})
 	register.Register(&register.Test{
 		Name:        "coreos.locksmith.tls",
 		Run:         locksmithTLS,
 		ClusterSize: 1,
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 		UserData: conf.Ignition(`{
   "ignition": { "version": "2.0.0" },
   "systemd": {

--- a/kola/tests/misc/auth.go
+++ b/kola/tests/misc/auth.go
@@ -25,6 +25,8 @@ func init() {
 		ClusterSize: 1,
 		Name:        "coreos.auth.verify",
 		Distros:     []string{"cl", "fcos", "rhcos"},
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 }
 

--- a/kola/tests/misc/cgroup1.go
+++ b/kola/tests/misc/cgroup1.go
@@ -38,6 +38,8 @@ func init() {
 		},
 		Distros:    []string{"cl"},
 		MinVersion: semver.Version{Major: 3033},
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 }
 

--- a/kola/tests/misc/cloudinit.go
+++ b/kola/tests/misc/cloudinit.go
@@ -34,6 +34,7 @@ write_files:
     content: bar`),
 		Distros:          []string{"cl"},
 		ExcludePlatforms: []string{"qemu-unpriv"},
+		// This should run on all clouds
 	})
 	register.Register(&register.Test{
 		Run:         CloudInitScript,
@@ -50,6 +51,8 @@ chmod 700 ~core/.ssh
 chmod 600 ~core/.ssh/authorized_keys`),
 		Distros:          []string{"cl"},
 		ExcludePlatforms: []string{"qemu-unpriv"},
+		// When cl.cloudinit.basic passed we don't need to run this on all clouds
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 }
 

--- a/kola/tests/misc/falco.go
+++ b/kola/tests/misc/falco.go
@@ -11,7 +11,8 @@ func init() {
 		ClusterSize: 1,
 		Name:        "cl.misc.falco",
 		Distros:     []string{"cl"},
-		Platforms:   []string{"qemu"},
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu"},
 		// falco builder container can't handle our arm64 config (yet)
 		Architectures: []string{"amd64"},
 		// selinux blocks insmod from within container

--- a/kola/tests/misc/files.go
+++ b/kola/tests/misc/files.go
@@ -28,6 +28,8 @@ func init() {
 		ClusterSize: 1,
 		Name:        "cl.filesystem",
 		Distros:     []string{"cl"},
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 }
 

--- a/kola/tests/misc/grub.go
+++ b/kola/tests/misc/grub.go
@@ -160,13 +160,15 @@ coreos:
 
 func init() {
 	register.Register(&register.Test{
-		Run:              UpdateGrubNop,
-		ClusterSize:      1,
-		Name:             "cl.update.grubnop",
-		UserData:         grubUpdaterConf,
-		MinVersion:       semver.Version{Major: 1745},
-		Architectures:    []string{"amd64"},
-		Distros:          []string{"cl"},
+		Run:           UpdateGrubNop,
+		ClusterSize:   1,
+		Name:          "cl.update.grubnop",
+		UserData:      grubUpdaterConf,
+		MinVersion:    semver.Version{Major: 1745},
+		Architectures: []string{"amd64"},
+		Distros:       []string{"cl"},
+		// This test is normally not related to the cloud environment
+		Platforms:        []string{"qemu"},
 		ExcludePlatforms: []string{"qemu-unpriv"},
 	})
 }

--- a/kola/tests/misc/install.go
+++ b/kola/tests/misc/install.go
@@ -40,6 +40,7 @@ func init() {
 }`),
 		Distros:          []string{"cl"},
 		ExcludePlatforms: []string{"azure"},
+		// This should run on all clouds to test the relation of Ignition and cloudinit
 	})
 }
 

--- a/kola/tests/misc/network.go
+++ b/kola/tests/misc/network.go
@@ -34,6 +34,8 @@ func init() {
 		ClusterSize: 1,
 		Name:        "cl.network.listeners",
 		Distros:     []string{"cl"},
+		// This test is normally not related to the cloud environment unless the OEM tools would unexpectedly listen on ports
+		Platforms: []string{"qemu", "qemu-unpriv"},
 		// be sure to notice listeners in the docker stack
 		UserData: conf.ContainerLinuxConfig(`systemd:
   units:
@@ -47,6 +49,8 @@ func init() {
 		Name:        "cl.network.listeners.legacy",
 		Distros:     []string{"cl"},
 		EndVersion:  semver.Version{Major: 1967},
+		// This test is normally not related to the cloud environment unless the OEM tools would unexpectedly listen on ports
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 	register.Register(&register.Test{
 		Run:              NetworkInitramfsSecondBoot,

--- a/kola/tests/misc/nfs.go
+++ b/kola/tests/misc/nfs.go
@@ -57,6 +57,8 @@ func init() {
 		// Disabled on Azure because setting hostname
 		// is required at the instance creation level
 		ExcludePlatforms: []string{"azure"},
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 	// TODO: enable FCOS when FCCT exists
 	register.Register(&register.Test{
@@ -68,6 +70,8 @@ func init() {
 		// Disabled on Azure because setting hostname
 		// is required at the instance creation level
 		ExcludePlatforms: []string{"azure"},
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 }
 

--- a/kola/tests/misc/ntp.go
+++ b/kola/tests/misc/ntp.go
@@ -32,9 +32,10 @@ var timesyncdMsgs = [][]byte{
 
 func init() {
 	register.Register(&register.Test{
-		Run:              NTP,
-		ClusterSize:      0,
-		Name:             "linux.ntp",
+		Run:         NTP,
+		ClusterSize: 0,
+		Name:        "linux.ntp",
+		// This test is normally not related to the cloud environment
 		Platforms:        []string{"qemu"},
 		ExcludePlatforms: []string{"qemu-unpriv"},
 		Distros:          []string{"cl"},

--- a/kola/tests/misc/omaha.go
+++ b/kola/tests/misc/omaha.go
@@ -28,9 +28,10 @@ import (
 
 func init() {
 	register.Register(&register.Test{
-		Run:              OmahaPing,
-		ClusterSize:      0,
-		Name:             "cl.omaha.ping",
+		Run:         OmahaPing,
+		ClusterSize: 0,
+		Name:        "cl.omaha.ping",
+		// This test is normally not related to the cloud environment
 		Platforms:        []string{"qemu"},
 		ExcludePlatforms: []string{"qemu-unpriv"},
 		Distros:          []string{"cl"},

--- a/kola/tests/misc/raid.go
+++ b/kola/tests/misc/raid.go
@@ -182,9 +182,10 @@ func init() {
 			// once Ignition supports it.
 			Run:         runRootOnRaid,
 			ClusterSize: 0,
-			Platforms:   []string{"qemu"},
-			Name:        fmt.Sprintf("cl.disk.%s.root", raidLevel),
-			Distros:     []string{"cl"},
+			// This test is normally not related to the cloud environment
+			Platforms: []string{"qemu"},
+			Name:      fmt.Sprintf("cl.disk.%s.root", raidLevel),
+			Distros:   []string{"cl"},
 		})
 
 		// data partition
@@ -207,6 +208,8 @@ func init() {
 			Name:        fmt.Sprintf("cl.disk.%s.data", raidLevel),
 			UserData:    userDataData,
 			Distros:     []string{"cl"},
+			// This test is normally not related to the cloud environment
+			Platforms: []string{"qemu", "qemu-unpriv"},
 		})
 	}
 }

--- a/kola/tests/misc/selinux.go
+++ b/kola/tests/misc/selinux.go
@@ -30,24 +30,32 @@ func init() {
 		ClusterSize: 1,
 		Name:        "coreos.selinux.enforce",
 		Distros:     []string{"cl", "fcos", "rhcos"},
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 	register.Register(&register.Test{
 		Run:         SelinuxBoolean,
 		ClusterSize: 1,
 		Name:        "coreos.selinux.boolean",
 		Distros:     []string{"cl", "fcos", "rhcos"},
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 	register.Register(&register.Test{
 		Run:         SelinuxBooleanPersist,
 		ClusterSize: 1,
 		Name:        "rhcos.selinux.boolean.persist",
 		Distros:     []string{"fcos", "rhcos"},
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 	register.Register(&register.Test{
 		Run:         SelinuxManage,
 		ClusterSize: 1,
 		Name:        "rhcos.selinux.manage",
 		Distros:     []string{"rhcos"},
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 }
 

--- a/kola/tests/misc/tls.go
+++ b/kola/tests/misc/tls.go
@@ -35,6 +35,8 @@ func init() {
 		ClusterSize:    1,
 		Name:           "coreos.tls.fetch-urls",
 		ExcludeDistros: []string{"rhcos", "fcos"}, // wget not included in *COS
+		// This test is normally not related to the cloud environment (and we have other tests for networking)
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 }
 

--- a/kola/tests/misc/toolbox.go
+++ b/kola/tests/misc/toolbox.go
@@ -27,6 +27,8 @@ func init() {
 		ClusterSize: 1,
 		Name:        "cl.toolbox.dnf-install",
 		Distros:     []string{"cl"},
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 }
 

--- a/kola/tests/misc/update.go
+++ b/kola/tests/misc/update.go
@@ -46,6 +46,8 @@ func init() {
 		Name:        "cl.update.reboot",
 		UserData:    disableUpdateEngine,
 		Distros:     []string{"cl"},
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 	register.Register(&register.Test{
 		Run:         RecoverBadVerity,
@@ -54,6 +56,8 @@ func init() {
 		Flags:       []register.Flag{register.NoEmergencyShellCheck, register.NoKernelPanicCheck},
 		UserData:    disableUpdateEngine,
 		Distros:     []string{"cl"},
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 	register.Register(&register.Test{
 		Run:         RecoverBadUsr,
@@ -62,6 +66,8 @@ func init() {
 		Flags:       []register.Flag{register.NoEmergencyShellCheck},
 		UserData:    disableUpdateEngine,
 		Distros:     []string{"cl"},
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 }
 

--- a/kola/tests/misc/users.go
+++ b/kola/tests/misc/users.go
@@ -28,6 +28,8 @@ func init() {
 		ExcludePlatforms: []string{"gce"},
 		Name:             "cl.users.shells",
 		Distros:          []string{"cl"},
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 }
 

--- a/kola/tests/misc/verity.go
+++ b/kola/tests/misc/verity.go
@@ -37,6 +37,8 @@ func init() {
 		ExcludePlatforms: []string{"qemu-unpriv"},
 		Flags:            []register.Flag{register.NoKernelPanicCheck},
 		MinVersion:       semver.Version{Major: 2943},
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 }
 

--- a/kola/tests/packages/packages.go
+++ b/kola/tests/packages/packages.go
@@ -25,6 +25,8 @@ func init() {
 		ClusterSize: 1,
 		Name:        "packages",
 		Distros:     []string{"cl"},
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 }
 

--- a/kola/tests/systemd/journald.go
+++ b/kola/tests/systemd/journald.go
@@ -63,6 +63,8 @@ func init() {
 		// Disabled on Azure because setting hostname
 		// is required at the instance creation level
 		ExcludePlatforms: []string{"azure"},
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 }
 

--- a/kola/tests/systemd/sysext.go
+++ b/kola/tests/systemd/sysext.go
@@ -16,7 +16,9 @@ func init() {
 		Run:         checkSysextSimple,
 		ClusterSize: 1,
 		Distros:     []string{"cl"},
-		MinVersion:  semver.Version{Major: 3185},
+		// This test is normally not related to the cloud environment
+		Platforms:  []string{"qemu", "qemu-unpriv"},
+		MinVersion: semver.Version{Major: 3185},
 		UserData: conf.ContainerLinuxConfig(`storage:
   files:
     - path: /etc/extensions/test/usr/lib/extension-release.d/extension-release.test

--- a/kola/tests/systemd/sysusers.go
+++ b/kola/tests/systemd/sysusers.go
@@ -25,6 +25,8 @@ func init() {
 		ClusterSize: 1,
 		Name:        "systemd.sysusers.gshadow",
 		Distros:     []string{"cl", "fcos"},
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 }
 

--- a/kola/tests/torcx/torcx.go
+++ b/kola/tests/torcx/torcx.go
@@ -27,7 +27,9 @@ func init() {
 	register.Register(&register.Test{
 		Run:         torcxEnable,
 		ClusterSize: 1,
-		Name:        "torcx.enable-service",
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
+		Name:      "torcx.enable-service",
 		UserData: conf.ContainerLinuxConfig(`
 systemd:
   units:

--- a/kola/tests/update/update.go
+++ b/kola/tests/update/update.go
@@ -41,6 +41,8 @@ func init() {
 			"Omaha": Serve,
 		},
 		Distros: []string{"cl"},
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 }
 


### PR DESCRIPTION
The number of tests causes the test time to be many hours on some of
the platforms and also costs money and energy while many tests are not
really adding much value when being tested on each of the platforms.
Some very generic tests already were limited to QEMU which is a good
solution for now, even if that means that the execution of all possible
tests on a platform now requires a source code change because we don't
have a flag to allow running additional tests when wanted.
Limit the execution of generic tests to QEMU. These generic tests are
not expected to have a different result on a cloud environment unless
something fundamental is at error. For these fundamental things we
rely on tests that still get executed on each cloud, e.g., to test
Ignition and networking, but we also rely on end-to-end tests such as
the kubeadm test. Each test now has a comment that tells whether the
execution on all clouds is wanted or not and why. The hope is that with
focused tests we don't waste our time to wait for unnecessary tests or
even have to restart them multiple times because they are flaky. Also,
with a reduced list of tests we can easily add new ones that we think
are missing but didn't realize before because there were to many, or
didn't want to add because the test time was too high already.

See https://github.com/flatcar-linux/Flatcar/issues/654

## How to use

We can compare the `kola list --filter --platform=X` output before and after the change

## Testing done

```
kola list --filter --platform=qemu
kola list --filter --platform=aws
kola list --filter --platform=do
kola list --filter --platform=azure
kola list --filter --platform=gce
kola list --filter --platform=equinixmetal
```

Here the sample output for equinixmetal:
```
kola list --filter --platform=equinixmetal | cut  -f 1
Test Name

cl.basic
cl.cloudinit.basic
cl.etcd-member.discovery
cl.flannel.udp
cl.flannel.vxlan
cl.ignition.misc.empty
cl.ignition.v1.noop
cl.ignition.v2.btrfsroot
cl.ignition.v2.noop
cl.install.cloudinit
cl.internet
cl.metadata.equinixmetal
cl.network.initramfs.second-boot
coreos.ignition.once
coreos.ignition.resource.local
coreos.ignition.resource.remote
coreos.ignition.sethostname
coreos.ignition.ssh.key
docker.network
kubeadm.v1.22.7.calico.base
kubeadm.v1.22.7.calico.cgroupv1.base
kubeadm.v1.22.7.cilium.base
kubeadm.v1.22.7.cilium.cgroupv1.base
kubeadm.v1.22.7.flannel.base
kubeadm.v1.22.7.flannel.cgroupv1.base
kubeadm.v1.23.4.calico.base
kubeadm.v1.23.4.cilium.base
kubeadm.v1.23.4.flannel.base
kubeadm.v1.24.1.calico.base
kubeadm.v1.24.1.cilium.base
kubeadm.v1.24.1.flannel.base
```
