### PR TITLE
kola/tests: test resolv.conf symlink more thoroughly

### DIFF
--- a/kola/tests/coretest/core.go
+++ b/kola/tests/coretest/core.go
@@ -254,6 +254,14 @@ func TestSymlinkResolvConf() error {
 	if !IsLink(f) {
 		return fmt.Errorf("/etc/resolv.conf is not a symlink.")
 	}
+	// check that resolv.conf points to the correct file
+	target, err := filepath.EvalSymlinks("/etc/resolv.conf")
+	if err != nil {
+		return fmt.Errorf("SymlinkResolvConf: readlink: %v", err)
+	}
+	if target != "/run/systemd/resolve/resolv.conf" {
+		return fmt.Errorf("/etc/resolv.conf points at the wrong file: %s", target)
+	}
 	return nil
 }
 


### PR DESCRIPTION
# kola/tests: test resolv.conf symlink more thoroughly

Extend TestSymlinkResolvConf to actually read the symlink and compare to the expected value.

## How to use

`./bin/kola run cl.basic`

## Testing done

Current nightly run (fails correctly): http://jenkins.infra.kinvolk.io:8080/job/os/job/kola/job/qemu/850/console
Branch with fix (succeeds): http://jenkins.infra.kinvolk.io:8080/job/os/job/kola/job/qemu/851/console

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
