### PR TITLE
test/networkd: add wireguard setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Kubernetes test for release 1.24.1 ([#337](https://github.com/flatcar-linux/mantle/pull/337))
 - Added storage abstraction for Equinix Metal tests (SSH can be used in addition of Google Cloud Storage) ([#340](https://github.com/flatcar-linux/mantle/pull/340))
 - `plume prune` support for soft-deleting AWS images and more advanced retention strategies ([#343](https://github.com/flatcar-linux/mantle/pull/343))
+- Added simple wireguard test ([#348](https://github.com/flatcar-linux/mantle/pull/348))
 
 ### Changed
 - removed `packet` occurrences in favor of `equinixmetal` ([#277](https://github.com/flatcar-linux/mantle/pull/277))


### PR DESCRIPTION
simple setup to test IP is assigned as expected.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

To be tested with: https://github.com/flatcar-linux/coreos-overlay/pull/2061 - currently it's failing but it works when adding the following section:
```yml
storage:
  files:
    - path: /etc/systemd/network/zz-default.network.d/wg.conf
      contents:
        inline: |
          [Match]
          Type=!wireguard
```

as suggested in the `::coreos-overlay` PR.