### PR TITLE
openstack: run test with only 1 public IP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added storage abstraction for Equinix Metal tests (SSH can be used in addition of Google Cloud Storage) ([#340](https://github.com/flatcar-linux/mantle/pull/340))
 - `plume prune` support for soft-deleting AWS images and more advanced retention strategies ([#343](https://github.com/flatcar-linux/mantle/pull/343))
 - Added simple wireguard test ([#348](https://github.com/flatcar-linux/mantle/pull/348))
+- Added SSH proxy jump to Openstack platform ([#349](https://github.com/flatcar-linux/mantle/pull/349))
 
 ### Changed
 - removed `packet` occurrences in favor of `equinixmetal` ([#277](https://github.com/flatcar-linux/mantle/pull/277))

--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -161,6 +161,9 @@ func init() {
 	sv(&kola.OpenStackOptions.Network, "openstack-network", "", "OpenStack network")
 	sv(&kola.OpenStackOptions.Domain, "openstack-domain", "", "OpenStack domain ID")
 	sv(&kola.OpenStackOptions.FloatingIPPool, "openstack-floating-ip-pool", "", "OpenStack floating IP pool for Compute v2 networking")
+	sv(&kola.OpenStackOptions.Host, "openstack-host", "", "Host can be used to optionally SSH into deployed VMs from the OpenStack host")
+	sv(&kola.OpenStackOptions.User, "openstack-user", "", "User is the one used for the SSH connection to the Host")
+	sv(&kola.OpenStackOptions.Keyfile, "openstack-keyfile", "", "Keyfile is the absolute path to private SSH key file for the User on the Host")
 
 	// packet-specific options (kept for compatiblity but marked as deprecated)
 	sv(&kola.EquinixMetalOptions.ConfigPath, "packet-config-file", "", "Packet config file (default \"~/"+auth.EquinixMetalConfigPath+"\")")

--- a/network/jump.go
+++ b/network/jump.go
@@ -1,0 +1,67 @@
+// Copyright The Mantle Authors.
+// SPDX-License-Identifier: Apache-2.0
+package network
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+
+	"golang.org/x/crypto/ssh"
+)
+
+var _ Dialer = (*JumpDialer)(nil)
+
+// JumpDialer is a RetryDialer from a proxy.
+type JumpDialer struct {
+	RetryDialer
+	user    string
+	addr    string
+	keyfile string
+}
+
+// NewJumpDialer initializes a JumpDialer to establish a SSH Proxy Jump.
+func NewJumpDialer(addr, user, keyfile string) *JumpDialer {
+	return &JumpDialer{
+		RetryDialer: RetryDialer{
+			Dialer: &net.Dialer{
+				Timeout:   DefaultTimeout,
+				KeepAlive: DefaultKeepAlive,
+			},
+			Retries: DefaultRetries,
+		},
+		user:    user,
+		addr:    addr,
+		keyfile: keyfile,
+	}
+}
+
+// Dial connects to a remote address, retrying on failure.
+func (d *JumpDialer) Dial(network, address string) (c net.Conn, err error) {
+	key, err := ioutil.ReadFile(d.keyfile)
+	if err != nil {
+		return nil, fmt.Errorf("reading private key: %w", err)
+	}
+
+	signer, err := ssh.ParsePrivateKey(key)
+	if err != nil {
+		return nil, fmt.Errorf("parsing private key: %w", err)
+	}
+
+	cfg := &ssh.ClientConfig{
+		User: d.user,
+		// this is only used for testing - it's ok to live with that.
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Auth: []ssh.AuthMethod{
+			ssh.PublicKeys(signer),
+		},
+	}
+
+	addr := ensurePortSuffix(d.addr, defaultPort)
+	client, err := ssh.Dial("tcp", addr, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("creating SSH client: %w", err)
+	}
+
+	return client.Dial(network, address)
+}

--- a/platform/api/openstack/api.go
+++ b/platform/api/openstack/api.go
@@ -64,6 +64,12 @@ type Options struct {
 	Domain string
 	// Floating IP Pool
 	FloatingIPPool string
+	// Host can be used to optionally SSH into deployed VMs from the OpenStack host
+	Host string
+	// User is the one used for the SSH connection to the Host
+	User string
+	// Keyfile is the abs. path to private SSH key file for the User on the Host
+	Keyfile string
 }
 
 type Server struct {


### PR DESCRIPTION
When spawning instance in OpenStack, VMs need to attach an interface with a public IP in order to SSH into it. With this change, we can now SSH proxy jump into the `devstack` host (Openstack dev environment)  into the VM deployed in the public network.

![tmp hsExzPr6Z4](https://user-images.githubusercontent.com/28657343/183076973-9ca570b2-51a1-4d7d-b9f2-1956b68f724c.png)

This reduce the dependency to floating IPs.

Related to: https://github.com/flatcar-linux/Flatcar/issues/785

Tests:
```
sudo ./bin/kola run --openstack-network public --openstack-domain default --platform openstack --openstack-flavor ds1G --openstack-user core --openstack-host 147.28... --openstack-keyfile ./id_rsa --openstack-image flatcar-stable --openstack-config-file ./openstack.json bpf.execsnoop
```
