### PR TITLE
network: create one connection to the jump host

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.13
+        go-version: <=1.18.5
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/platform/machine/openstack/flight.go
+++ b/platform/machine/openstack/flight.go
@@ -54,7 +54,12 @@ func NewFlight(opts *openstack.Options) (platform.Flight, error) {
 			return nil, fmt.Errorf("--openstack-user and --openstack-keyfile can't be empty when using --openstack-host")
 		}
 
-		bf, err = platform.NewBaseFlightWithDialer(opts.Options, Platform, ctplatform.OpenStackMetadata, network.NewJumpDialer(opts.Host, opts.User, opts.Keyfile))
+		d, err := network.NewJumpDialer(opts.Host, opts.User, opts.Keyfile)
+		if err != nil {
+			return nil, fmt.Errorf("setting proxy jump dialer: %w", err)
+		}
+
+		bf, err = platform.NewBaseFlightWithDialer(opts.Options, Platform, ctplatform.OpenStackMetadata, d)
 		if err != nil {
 			return nil, fmt.Errorf("creating base flight with jump dialer: %w", err)
 		}


### PR DESCRIPTION
this avoid to create a new connection for each run, we just create one
shared SSH connection for one flight instance.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

Tried with `--parallel 2 kubeadm.v1.23.4.flannel.base kubeadm.v1.23.4.calico.base`