### PR TITLE
kola/tests/kubeadm: Fix version check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Removed Kubernetes test for release 1.21.10 ([#337](https://github.com/flatcar-linux/mantle/pull/337))
 - Removed enforced SELinux for `kubeadm.flannel.*` tests ([#337](https://github.com/flatcar-linux/mantle/pull/337))
 
+### Fixed
+- Fix version check in kubeadm tests ([#353](https://github.com/flatcar-linux/mantle/pull/353))
+
 ## [0.18.0] - 12/01/2022
 ### Security
 - go: Update golang.org/x/{text,crypto} ([#262](https://github.com/flatcar-linux/mantle/pull/262))

--- a/kola/tests/kubeadm/kubeadm.go
+++ b/kola/tests/kubeadm/kubeadm.go
@@ -159,7 +159,7 @@ func init() {
 					flags = append(flags, register.NoEnableSelinux)
 				}
 
-				if version == "1.24.1" {
+				if version == "v1.24.1" {
 					major = 3033
 				}
 


### PR DESCRIPTION
The version is prefixed with the v character, so not sure if this
check ever worked before - the test was still being run for LTS 2011,
which has version 2605, so lower than 3033.