### PR TITLE
api/equinixmetal: Make timeouts configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added URL support for Openstack image creation ([#350](https://github.com/flatcar-linux/mantle/pull/350))
 - kola tests for Cilium IPSec encryption ([#292](https://github.com/flatcar-linux/mantle/pull/292))
 - Kubernetes test for release 1.25.0 ([#360](https://github.com/flatcar-linux/mantle/pull/360))
+- Configurable timeouts for installation and launching Equinix Metal instances through `--equinixmetal-install-timeout` and `--equinixmetal-launch-timeout` flags ([#354](https://github.com/flatcar-linux/mantle/pull/354))
+- Configurable timeouts for attaching to machine's journal and for machine checks through `--ssh-retries` and `--ssh-timeout` flags ([#354](https://github.com/flatcar-linux/mantle/pull/354))
 
 ### Changed
 - removed `packet` occurrences in favor of `equinixmetal` ([#277](https://github.com/flatcar-linux/mantle/pull/277))

--- a/cmd/kola/bootchart.go
+++ b/cmd/kola/bootchart.go
@@ -64,7 +64,9 @@ func runBootchart(cmd *cobra.Command, args []string) {
 	defer flight.Destroy()
 
 	cluster, err := flight.NewCluster(&platform.RuntimeConfig{
-		OutputDir: outputDir,
+		OutputDir:  outputDir,
+		SSHRetries: kola.Options.SSHRetries,
+		SSHTimeout: kola.Options.SSHTimeout,
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Cluster failed: %v\n", err)

--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -22,6 +22,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
@@ -57,6 +58,9 @@ var (
 		"amd64-usr": "bios-256k.bin",
 		"arm64-usr": sdk.BuildRoot() + "/images/arm64-usr/latest/flatcar_production_qemu_uefi_efi_code.fd",
 	}
+
+	kolaSSHRetries = 60
+	kolaSSHTimeout = 10 * time.Second
 )
 
 func init() {
@@ -64,6 +68,7 @@ func init() {
 	bv := root.PersistentFlags().BoolVar
 	ss := root.PersistentFlags().StringSlice
 	dv := root.PersistentFlags().DurationVar
+	iv := root.PersistentFlags().IntVar
 
 	// general options
 	sv(&outputDir, "output-dir", "", "Temporary output directory for test data and logs")
@@ -78,6 +83,8 @@ func init() {
 	ss("debug-systemd-unit", []string{}, "full-unit-name.service to enable SYSTEMD_LOG_LEVEL=debug on. Specify multiple times for multiple units.")
 	sv(&kola.UpdatePayloadFile, "update-payload", "", "Path to an update payload that should be made available to tests")
 	sv(&kola.Options.IgnitionVersion, "ignition-version", "", "Ignition version override: v2, v3")
+	iv(&kola.Options.SSHRetries, "ssh-retries", kolaSSHRetries, "Number of retries with the SSH timeout when starting the machine")
+	dv(&kola.Options.SSHTimeout, "ssh-timeout", kolaSSHTimeout, "A timeout for a single try of establishing an SSH connection when starting the machine")
 
 	// rhcos-specific options
 	sv(&kola.Options.OSContainer, "oscontainer", "", "oscontainer image pullspec for pivot (RHCOS only)")
@@ -293,6 +300,19 @@ func syncOptions() error {
 		if !ok {
 			return fmt.Errorf("Distribution %q has no default Ignition version", kola.Options.Distribution)
 		}
+	}
+
+	if kola.Options.SSHRetries == 0 {
+		kola.Options.SSHRetries = kolaSSHRetries
+	}
+	if kola.Options.SSHRetries < 0 {
+		return fmt.Errorf("Number of SSH retries can't be negative, is %d", kola.Options.SSHRetries)
+	}
+	if kola.Options.SSHTimeout == 0 {
+		kola.Options.SSHTimeout = kolaSSHTimeout
+	}
+	if kola.Options.SSHTimeout < 0 {
+		return fmt.Errorf("SSH timeout can't be negative, is %v", kola.Options.SSHTimeout)
 	}
 
 	return nil

--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -63,6 +63,7 @@ func init() {
 	sv := root.PersistentFlags().StringVar
 	bv := root.PersistentFlags().BoolVar
 	ss := root.PersistentFlags().StringSlice
+	dv := root.PersistentFlags().DurationVar
 
 	// general options
 	sv(&outputDir, "output-dir", "", "Temporary output directory for test data and logs")
@@ -205,6 +206,8 @@ func init() {
 	sv(&kola.EquinixMetalOptions.RemoteUser, "equinixmetal-remote-user", "core", "the user for SSH connection to the remote storage")
 	sv(&kola.EquinixMetalOptions.RemoteSSHPrivateKeyPath, "equinixmetal-remote-ssh-private-key-path", "./id_rsa", "the path to SSH private key for SSH connection to the remote storage")
 	sv(&kola.EquinixMetalOptions.RemoteDocumentRoot, "equinixmetal-remote-document-root", "/var/www", "the absolute path to the document root of the webserver for serving temporary files")
+	dv(&kola.EquinixMetalOptions.LaunchTimeout, "equinixmetal-launch-timeout", 0, "Timeout used for waiting for instance to launch")
+	dv(&kola.EquinixMetalOptions.InstallTimeout, "equinixmetal-install-timeout", 0, "Timeout used for waiting for installation to finish")
 
 	// QEMU-specific options
 	sv(&kola.QEMUOptions.Board, "board", defaultTargetBoard, "target board")

--- a/cmd/kola/spawn.go
+++ b/cmd/kola/spawn.go
@@ -126,6 +126,8 @@ func doSpawn(cmd *cobra.Command, args []string) error {
 	cluster, err := flight.NewCluster(&platform.RuntimeConfig{
 		OutputDir:        outputDir,
 		AllowFailedUnits: true,
+		SSHRetries:       kola.Options.SSHRetries,
+		SSHTimeout:       kola.Options.SSHTimeout,
 	})
 	if err != nil {
 		return fmt.Errorf("Cluster failed: %v", err)

--- a/cmd/kola/updatepayload.go
+++ b/cmd/kola/updatepayload.go
@@ -144,7 +144,9 @@ func runUpdateTest() error {
 	defer flight.Destroy()
 
 	cluster, err := flight.NewCluster(&platform.RuntimeConfig{
-		OutputDir: outputDir,
+		OutputDir:  outputDir,
+		SSHRetries: kola.Options.SSHRetries,
+		SSHTimeout: kola.Options.SSHTimeout,
 	})
 	if err != nil {
 		return fmt.Errorf("new cluster: %v", err)

--- a/kola/harness.go
+++ b/kola/harness.go
@@ -423,7 +423,9 @@ func getClusterSemver(flight platform.Flight, outputDir string) (*semver.Version
 	}
 
 	cluster, err := flight.NewCluster(&platform.RuntimeConfig{
-		OutputDir: testDir,
+		OutputDir:  testDir,
+		SSHRetries: Options.SSHRetries,
+		SSHTimeout: Options.SSHTimeout,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("creating cluster for semver check: %v", err)
@@ -492,6 +494,8 @@ func runTest(h *harness.H, t *register.Test, pltfrm string, flight platform.Flig
 		NoSSHKeyInUserData: t.HasFlag(register.NoSSHKeyInUserData),
 		NoSSHKeyInMetadata: t.HasFlag(register.NoSSHKeyInMetadata),
 		NoEnableSelinux:    t.HasFlag(register.NoEnableSelinux),
+		SSHRetries:         Options.SSHRetries,
+		SSHTimeout:         Options.SSHTimeout,
 	}
 	c, err := flight.NewCluster(rconf)
 	if err != nil {

--- a/platform/journal.go
+++ b/platform/journal.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/coreos/pkg/multierror"
 
@@ -111,7 +112,8 @@ func (j *Journal) Start(ctx context.Context, m Machine) error {
 		}
 		return true, nil
 	}
-	if err := util.WaitUntilReady(sshTimeout*sshRetries, sshTimeout, start); err != nil {
+	rc := m.RuntimeConf()
+	if err := util.WaitUntilReady(rc.SSHTimeout*time.Duration(rc.SSHRetries), rc.SSHTimeout, start); err != nil {
 		cancel()
 		return fmt.Errorf("ssh journalctl failed: %v: %v", err, lastErr)
 	}


### PR DESCRIPTION
This could be used by vendor tests to increase timeouts for running tests on big EM instances

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
