### PR TITLE
kola: More calico fixes

### DIFF
--- a/.github/workflows/sync-calico-version.yml
+++ b/.github/workflows/sync-calico-version.yml
@@ -48,3 +48,11 @@ jobs:
           commit-message: Update calico to ${{ steps.update-links.outputs.CALICO_VERSION }}
           reviewers: flatcar-linux/flatcar-maintainers
           delete-branch: true
+          body: |
+            Before merging this pull request, PLEASE make sure that a manifest based
+            on `custom-resources.yaml` in `kola/tests/kubeadm/templates.go`
+            and `kola/tests/kubeadm/testdata/master-calico-script.sh` is in sync
+            with https://raw.githubusercontent.com/projectcalico/calico/${{ steps.update-links.outputs.CALICO_VERSION }}/manifests/custom-resources.yaml
+            and amend the commit in this pull request with an update
+            of the `# Source:` comment there to match the new version.
+            Thank you.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Fix version check in kubeadm tests ([#353](https://github.com/flatcar-linux/mantle/pull/353))
+- Make Calico testing in kubeadm tests more reliable ([#359](https://github.com/flatcar-linux/mantle/pull/359))
 
 ## [0.18.0] - 12/01/2022
 ### Security

--- a/kola/tests/kubeadm/templates.go
+++ b/kola/tests/kubeadm/templates.go
@@ -384,6 +384,9 @@ EOF
 
 {{ if eq .CNI "calico" }}
     kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/v3.24.0/manifests/tigera-operator.yaml
+    # calico.yaml uses Installation and APIServer CRDs, so make sure that they are established.
+    kubectl -n tigera-operator wait --for condition=established --timeout=60s crd/installations.operator.tigera.io
+    kubectl -n tigera-operator wait --for condition=established --timeout=60s crd/apiservers.operator.tigera.io
     kubectl apply -f calico.yaml
 {{ end }}
 {{ if eq .CNI "flannel" }}

--- a/kola/tests/kubeadm/templates.go
+++ b/kola/tests/kubeadm/templates.go
@@ -340,7 +340,9 @@ EOF
 
 {{ if eq .CNI "calico" }}
 cat << EOF > calico.yaml
-# Source: https://docs.projectcalico.org/manifests/custom-resources.yaml
+# Source: https://raw.githubusercontent.com/projectcalico/calico/v3.24.0/manifests/custom-resources.yaml
+# This section includes base Calico installation configuration.
+# For more information, see: https://projectcalico.docs.tigera.io/master/reference/installation/api#operator.tigera.io/v1.Installation
 apiVersion: operator.tigera.io/v1
 kind: Installation
 metadata:
@@ -353,12 +355,22 @@ spec:
   calicoNetwork:
     # Note: The ipPools section cannot be modified post-install.
     ipPools:
-      - blockSize: 26
-        cidr: {{ .PodSubnet }}
-        encapsulation: VXLANCrossSubnet
-        natOutgoing: Enabled
-        nodeSelector: all()
+    - blockSize: 26
+      cidr: {{ .PodSubnet }}
+      encapsulation: VXLANCrossSubnet
+      natOutgoing: Enabled
+      nodeSelector: all()
   flexVolumePath: /opt/libexec/kubernetes/kubelet-plugins/volume/exec/
+
+---
+
+# This section configures the Calico API server.
+# For more information, see: https://projectcalico.docs.tigera.io/master/reference/installation/api#operator.tigera.io/v1.APIServer
+apiVersion: operator.tigera.io/v1
+kind: APIServer
+metadata:
+  name: default
+spec: {}
 EOF
 {{ end }}
 

--- a/kola/tests/kubeadm/templates.go
+++ b/kola/tests/kubeadm/templates.go
@@ -383,7 +383,7 @@ EOF
     chown -R core:core /home/core/.kube; chmod a+r /home/core/.kube/config;
 
 {{ if eq .CNI "calico" }}
-    kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/v3.24.0/manifests/tigera-operator.yaml
+    kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/v3.23.0/manifests/tigera-operator.yaml
     # calico.yaml uses Installation and APIServer CRDs, so make sure that they are established.
     kubectl -n tigera-operator wait --for condition=established --timeout=60s crd/installations.operator.tigera.io
     kubectl -n tigera-operator wait --for condition=established --timeout=60s crd/apiservers.operator.tigera.io

--- a/kola/tests/kubeadm/testdata/master-calico-script.sh
+++ b/kola/tests/kubeadm/testdata/master-calico-script.sh
@@ -74,7 +74,9 @@ EOF
 
 
 cat << EOF > calico.yaml
-# Source: https://docs.projectcalico.org/manifests/custom-resources.yaml
+# Source: https://raw.githubusercontent.com/projectcalico/calico/v3.24.0/manifests/custom-resources.yaml
+# This section includes base Calico installation configuration.
+# For more information, see: https://projectcalico.docs.tigera.io/master/reference/installation/api#operator.tigera.io/v1.Installation
 apiVersion: operator.tigera.io/v1
 kind: Installation
 metadata:
@@ -87,12 +89,22 @@ spec:
   calicoNetwork:
     # Note: The ipPools section cannot be modified post-install.
     ipPools:
-      - blockSize: 26
-        cidr: 192.168.0.0/17
-        encapsulation: VXLANCrossSubnet
-        natOutgoing: Enabled
-        nodeSelector: all()
+    - blockSize: 26
+      cidr: 192.168.0.0/17
+      encapsulation: VXLANCrossSubnet
+      natOutgoing: Enabled
+      nodeSelector: all()
   flexVolumePath: /opt/libexec/kubernetes/kubelet-plugins/volume/exec/
+
+---
+
+# This section configures the Calico API server.
+# For more information, see: https://projectcalico.docs.tigera.io/master/reference/installation/api#operator.tigera.io/v1.APIServer
+apiVersion: operator.tigera.io/v1
+kind: APIServer
+metadata:
+  name: default
+spec: {}
 EOF
 
 

--- a/kola/tests/kubeadm/testdata/master-calico-script.sh
+++ b/kola/tests/kubeadm/testdata/master-calico-script.sh
@@ -118,6 +118,9 @@ EOF
 
 
     kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/v3.24.0/manifests/tigera-operator.yaml
+    # calico.yaml uses Installation and APIServer CRDs, so make sure that they are established.
+    kubectl -n tigera-operator wait --for condition=established --timeout=60s crd/installations.operator.tigera.io
+    kubectl -n tigera-operator wait --for condition=established --timeout=60s crd/apiservers.operator.tigera.io
     kubectl apply -f calico.yaml
 
 


### PR DESCRIPTION
~I'll need to update the github action to mention in the created PR that these templates should be manually compared with the original versions.~

There seemed to be a race between using one manifest file to create CRDs and afterwards applying another manifest file that was using those CRDs. Sometimes the CRDs were not established, so the resources of that type could not be used. Use `kubectl wait` to make sure that those CRDs are ready.

While at it, sync our modified custom-resources.yaml manifest with the upstream and add a note about it to the github action. The note looks like in this PR: https://github.com/krnowak/mantle/pull/2.


Test run: http://jenkins.infra.kinvolk.io:8080/job/container/job/test/1988/console (note the `customresourcedefinition.apiextensions.k8s.io/installations.operator.tigera.io condition met` line in the output, after CRDs were created, but before the object of that type was created).