### PR TITLE
test/network: add vmware to wireguard test

### DIFF
--- a/kola/tests/misc/network.go
+++ b/kola/tests/misc/network.go
@@ -81,7 +81,7 @@ storage:
 
           [Peer]
           PublicKey = EQluuT9Wk0TFUDYlU/5fBsY3KPx/YsZxaM0lCvlLwF4=
-          AllowedIPs = 0.0.0.0/0, ::/0
+          AllowedIPs = 192.168.0.0/24
           Endpoint = 127.0.0.1:51820
     - path: /etc/wireguard/wg0.conf
       contents:

--- a/kola/tests/misc/network.go
+++ b/kola/tests/misc/network.go
@@ -65,8 +65,7 @@ func init() {
 		ClusterSize: 1,
 		Name:        "cl.network.wireguard",
 		Distros:     []string{"cl"},
-		// This test is normally not related to the cloud environment unless the OEM tools would unexpectedly listen on ports
-		Platforms: []string{"qemu", "qemu-unpriv"},
+		Platforms:   []string{"qemu", "qemu-unpriv", "esx"},
 		UserData: conf.Butane(`---
 variant: flatcar
 version: 1.0.0


### PR DESCRIPTION
Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

It has been raised on Matrix that wireguard does not seem working on VMWare.