### PR TITLE
equinixmetal: Exclude weird devices from flatcar installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Fix version check in kubeadm tests ([#353](https://github.com/flatcar-linux/mantle/pull/353))
 - Make Calico testing in kubeadm tests more reliable ([#359](https://github.com/flatcar-linux/mantle/pull/359))
+- Fix running tests on Equinix Metal s3.xlarge.x86 instanes ([#364](https://github.com/flatcar-linux/mantle/pull/364))
 
 ## [0.18.0] - 12/01/2022
 ### Security

--- a/platform/api/equinixmetal/api.go
+++ b/platform/api/equinixmetal/api.go
@@ -444,7 +444,9 @@ ExecStart=/usr/bin/curl --retry-delay 1 --retry 120 --retry-connrefused --retry-
 
 ExecStartPre=-/bin/bash -c 'lvchange -an /dev/mapper/*'
 ExecStartPre=-/bin/bash -c 'shopt -s nullglob; for disk in /dev/*d? /dev/nvme?n1; do wipefs --all --force $${disk}; done'
-ExecStart=/usr/bin/flatcar-install -s -f image.bin.bz2 %v /userdata
+# 259 is a major number of NVMe devices. They need to be excluded, because
+# the boot agent can't boot from them.
+ExecStart=/usr/bin/flatcar-install -s -e 259 -f image.bin.bz2 %v /userdata
 
 ExecStart=/usr/bin/systemctl --no-block isolate reboot.target
 

--- a/platform/api/equinixmetal/api.go
+++ b/platform/api/equinixmetal/api.go
@@ -294,7 +294,13 @@ func (a *API) CreateOrUpdateDevice(hostname string, conf *conf.Conf, console Con
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create device: %v", err)
 	}
+	destroyDevice := true
 	deviceID := device.ID
+	defer func() {
+		if destroyDevice {
+			a.DeleteDevice(deviceID)
+		}
+	}()
 
 	plog.Debugf("Created device: %q", deviceID)
 
@@ -302,20 +308,17 @@ func (a *API) CreateOrUpdateDevice(hostname string, conf *conf.Conf, console Con
 		err := a.startConsole(deviceID, device.Facility.Code, console)
 		consoleStarted = true
 		if err != nil {
-			a.DeleteDevice(deviceID)
 			return nil, err
 		}
 	}
 
 	device, err = a.waitForActive(deviceID)
 	if err != nil {
-		a.DeleteDevice(deviceID)
 		return nil, err
 	}
 
 	ipAddress := a.GetDeviceAddress(device, 4, true)
 	if ipAddress == "" {
-		a.DeleteDevice(deviceID)
 		return nil, fmt.Errorf("no public IP address found for %v", deviceID)
 	}
 
@@ -323,7 +326,6 @@ func (a *API) CreateOrUpdateDevice(hostname string, conf *conf.Conf, console Con
 
 	err = waitForInstall(ipAddress)
 	if err != nil {
-		a.DeleteDevice(deviceID)
 		return nil, fmt.Errorf("timed out waiting for flatcar-install: %v", err)
 	}
 
@@ -338,6 +340,7 @@ func (a *API) CreateOrUpdateDevice(hostname string, conf *conf.Conf, console Con
 
 	plog.Debugf("Finished installation of device: %q", deviceID)
 
+	destroyDevice = false
 	return device, nil
 }
 


### PR DESCRIPTION
`s3.xlarge.x86` has some nvme disks attached, which have the smallest size in bytes from all the available disks. Since we are passing the `-s` flag to `flatcar-install` (so the scripts find the smallest disk to install flatcar), they get picked. For some reason, they can't be booted. The nvme devices have major 259, whereas other disks - 8.

I had two ways of fixing the issue - either exclude 259, or include only 8. Went with the former.

During trying to find the fix I did some small cleanup.

The commit messages still need to be rewritten.

I also had a commit that drops fiddling with AlwaysPXE flag, and uses reinstall action instead. This might be something to consider, but it's certainly slower, since all the disks seem to be zeroed. So in case of `s3.xlarge.x86` instance, the reinstallation caused the timeout to be triggered. Maybe something for follow-up PR.

Fixes https://github.com/flatcar-linux/Flatcar/issues/834

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
