### PR TITLE
kubeadm/cilium: bump tested versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bumped Kubernetes binaries and CNI versions ([#297](https://github.com/flatcar-linux/mantle/pull/297))
 - GCP images are now published/tested with UEFI boot mode ([#322](https://github.com/flatcar-linux/mantle/pull/322))
 - Bumped Go version to 1.19 ([#352](https://github.com/flatcar-linux/mantle/pull/352))
+- Bumped Cilium version to 1.12.1 ([#365](https://github.com/flatcar-linux/mantle/pull/365))
+- Set SELinux in permissive mode for Cilium ([#365](https://github.com/flatcar-linux/mantle/pull/365))
 
 ### Removed
 - Remove `--repo-branch` option from cork ([#283](https://github.com/flatcar-linux/mantle/pull/283))

--- a/kola/tests/kubeadm/kubeadm.go
+++ b/kola/tests/kubeadm/kubeadm.go
@@ -73,8 +73,8 @@ var (
 	testConfig = map[string]map[string]interface{}{
 		"v1.24.1": map[string]interface{}{
 			"FlannelVersion":   "v0.18.1",
-			"CiliumVersion":    "1.11.5",
-			"CiliumCLIVersion": "v0.10.7",
+			"CiliumVersion":    "1.12.1",
+			"CiliumCLIVersion": "v0.12.2",
 			"CNIVersion":       "v1.1.1",
 			"CRIctlVersion":    "v1.24.2",
 			"ReleaseVersion":   "v0.13.0",
@@ -98,8 +98,8 @@ var (
 		},
 		"v1.23.4": map[string]interface{}{
 			"FlannelVersion":   "v0.16.3",
-			"CiliumVersion":    "1.11.2",
-			"CiliumCLIVersion": "v0.10.2",
+			"CiliumVersion":    "1.12.1",
+			"CiliumCLIVersion": "v0.12.2",
 			"CNIVersion":       "v1.0.1",
 			"CRIctlVersion":    "v1.22.0",
 			"ReleaseVersion":   "v0.4.0",
@@ -123,8 +123,8 @@ var (
 		},
 		"v1.22.7": map[string]interface{}{
 			"FlannelVersion":   "v0.16.3",
-			"CiliumVersion":    "1.11.2",
-			"CiliumCLIVersion": "v0.10.2",
+			"CiliumVersion":    "1.12.1",
+			"CiliumCLIVersion": "v0.12.2",
 			"CNIVersion":       "v1.0.1",
 			"CRIctlVersion":    "v1.22.0",
 			"ReleaseVersion":   "v0.4.0",

--- a/kola/tests/kubeadm/kubeadm.go
+++ b/kola/tests/kubeadm/kubeadm.go
@@ -186,7 +186,7 @@ func init() {
 					major = 3140
 				}
 
-				if CNI == "flannel" {
+				if CNI == "flannel" || CNI == "cilium" {
 					flags = append(flags, register.NoEnableSelinux)
 				}
 

--- a/kola/tests/kubeadm/templates.go
+++ b/kola/tests/kubeadm/templates.go
@@ -401,6 +401,7 @@ EOF
         --config enable-endpoint-routes=true \
         --config cluster-pool-ipv4-cidr={{ .PodSubnet }} \
         --version={{ .CiliumVersion }} 2>&1 | iconv --from-code utf-8 --to-code ascii//TRANSLIT
+    kubectl --namespace kube-system patch daemonset/cilium -p '{"spec":{"template":{"spec":{"containers":[{"name":"cilium-agent","securityContext":{"seLinuxOptions":{"level":"s0","type":"unconfined_t"}}}],"initContainers":[{"name":"mount-cgroup","securityContext":{"seLinuxOptions":{"level":"s0","type":"unconfined_t"}}},{"name":"apply-sysctl-overwrites","securityContext":{"seLinuxOptions":{"level":"s0","type":"unconfined_t"}}},{"name":"clean-cilium-state","securityContext":{"seLinuxOptions":{"level":"s0","type":"unconfined_t"}}}]}}}}'
     # --wait will wait for status to report success
     /opt/bin/cilium status --wait 2>&1 | iconv --from-code utf-8 --to-code ascii//TRANSLIT
 {{ end }}

--- a/kola/tests/kubeadm/testdata/master-cilium-script.sh
+++ b/kola/tests/kubeadm/testdata/master-cilium-script.sh
@@ -91,6 +91,7 @@ EOF
         --config enable-endpoint-routes=true \
         --config cluster-pool-ipv4-cidr=192.168.0.0/17 \
         --version=v0.11.1 2>&1 | iconv --from-code utf-8 --to-code ascii//TRANSLIT
+    kubectl --namespace kube-system patch daemonset/cilium -p '{"spec":{"template":{"spec":{"containers":[{"name":"cilium-agent","securityContext":{"seLinuxOptions":{"level":"s0","type":"unconfined_t"}}}],"initContainers":[{"name":"mount-cgroup","securityContext":{"seLinuxOptions":{"level":"s0","type":"unconfined_t"}}},{"name":"apply-sysctl-overwrites","securityContext":{"seLinuxOptions":{"level":"s0","type":"unconfined_t"}}},{"name":"clean-cilium-state","securityContext":{"seLinuxOptions":{"level":"s0","type":"unconfined_t"}}}]}}}}'
     # --wait will wait for status to report success
     /opt/bin/cilium status --wait 2>&1 | iconv --from-code utf-8 --to-code ascii//TRANSLIT
 


### PR DESCRIPTION
* kubeadm/cilium: bump CLI and tested Cilium version

    Starting from Cilium 1.12, {live,ready}ness probes are on :9879 while
    it was on :9876 on older versions. (See: https://github.com/cilium/cilium/commit/22cd47ef496be1c0b78ff8d146b2240810e78978)

    CLI made this change on versions greater or equal to 1.10.12 (See: https://github.com/cilium/cilium-cli/pull/869/files) - it
    results with a port mismatch 9879/9876 if we test the version 1.11.5.

    Basically Cilium is running fine but its status is not ready/healthy
    from a Kubernetes PoV.

* kubeadm/cilium: patch Cilium daemon set

    This is required even with Permissive mode. Can be dropped once `spc_t`
    is supported on Flatcar.

* kubeadm/cilium: disable SELinux for Cilium

    Once the daemon set is started with `unconfined_t` it does not work with
    enforced SELinux because it hits a denial from transitioning to `kernel_t` to
    `unconfined_t` (and this normal because currently everything runs with
    `kernel_t` including container runtimes)

    Can be dropped once it works fine with `spc_t` label with the SELinux
    upgrade.


<hr>

Tested multiple times on Openstack, the CI: http://jenkins.infra.kinvolk.io:8080/job/os/job/kola/job/packet/309/console and with kubernetes-1.25