### PR TITLE
kubeadm: bump cilium for kubernetes 1.22

### DIFF
--- a/kola/tests/kubeadm/kubeadm.go
+++ b/kola/tests/kubeadm/kubeadm.go
@@ -160,8 +160,8 @@ var (
 		},
 		"v1.22.7": map[string]interface{}{
 			"FlannelVersion":   "v0.16.3",
-			"CiliumVersion":    "1.12.1",
-			"CiliumCLIVersion": "v0.12.2",
+			"CiliumVersion":    "1.13.0-rc0",
+			"CiliumCLIVersion": "v0.12.3",
 			"CNIVersion":       "v1.0.1",
 			"CRIctlVersion":    "v1.22.0",
 			"ReleaseVersion":   "v0.4.0",


### PR DESCRIPTION
Some issue with iptables management, for example:
```
iptables -t filter -D OLD_CILIUM_FORWARD -m mark --mark 0xe00/0xf00 -m comm# Warning: iptables-legacy tables present, use iptables-legacy to see them
```

Which should actually be:
```
iptables -t filter -D OLD_CILIUM_FORWARD -m mark --mark 0xe00/0xf00 -m comment --comment "# Warning: iptables-legacy tables present, use iptables-legacy to see them"
```

It's solved with this commit: https://github.com/cilium/cilium/commit/c8d5d28ae30f5a4de666581b6c37c4c182da45c6

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

