### PR TITLE
plume/release: publish on the AWS Marketplace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Kubernetes test for release 1.25.0 ([#360](https://github.com/flatcar-linux/mantle/pull/360))
 - Configurable timeouts for installation and launching Equinix Metal instances through `--equinixmetal-install-timeout` and `--equinixmetal-launch-timeout` flags ([#354](https://github.com/flatcar-linux/mantle/pull/354))
 - Configurable timeouts for attaching to machine's journal and for machine checks through `--ssh-retries` and `--ssh-timeout` flags ([#354](https://github.com/flatcar-linux/mantle/pull/354))
+- AMI publishing on the AWS Marketplace ([#369](https://github.com/flatcar-linux/mantle/pull/369))
 
 ### Changed
 - removed `packet` occurrences in favor of `equinixmetal` ([#277](https://github.com/flatcar-linux/mantle/pull/277))

--- a/cmd/plume/prerelease.go
+++ b/cmd/plume/prerelease.go
@@ -72,6 +72,17 @@ var (
 	awsCredentialsFile string
 	verifyKeyFile      string
 	imageInfoFile      string
+	// productID is the AWS Marketplace offer ID.
+	productID string
+	// accessRoleARN is the ARN to give marketplace access to the AMI.
+	accessRoleARN string
+	// awsMarketplaceCredentialsFile is used for publishing
+	// the AMIs on the AWS Marketplace.
+	awsMarketplaceCredentialsFile string
+	// publishMarketplace is used to publish or not on the AWS Marketplace.
+	publishMarketplace bool
+	// username is the default user on instances launched by AWS Marketplace.
+	username string
 )
 
 type imageMetadataAbstract struct {


### PR DESCRIPTION
We use the us-east-1 AMIs ID to programmatically update the AWS Marketplace offer.

CI (or human) must provide the product-id and the access role ARN to update the offer. See also the documentation for the `ore aws update-offer` subcommand.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

Not tested - we can try it during the next release. It's designed to not fail if the update of the offer fails.

Related to: https://github.com/flatcar-linux/Flatcar/issues/838
Update of the offer itself: https://github.com/flatcar-linux/mantle/pull/282
