### PR TITLE
AWS prune all snapshots

### DIFF
--- a/cmd/ore/aws/delete.go
+++ b/cmd/ore/aws/delete.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/flatcar-linux/mantle/platform/api/aws"
 	"github.com/spf13/cobra"
 )
 
@@ -78,8 +79,12 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	plog.Debugf("S3 object: %v\n", s3URL)
 	s3BucketName := s3URL.Host
 	s3ObjectPath := strings.TrimPrefix(s3URL.Path, "/")
+	s3object := aws.BucketObject{
+		Bucket: s3BucketName,
+		Path:   s3ObjectPath,
+	}
 
-	err = API.RemoveImage(amiName, deleteImageName, s3BucketName, s3ObjectPath, nil)
+	err = API.RemoveImage(amiName, deleteImageName, s3object, nil)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "unable to delete: %v\n", err)
 		os.Exit(1)

--- a/cmd/ore/aws/upload.go
+++ b/cmd/ore/aws/upload.go
@@ -211,7 +211,11 @@ func runUpload(cmd *cobra.Command, args []string) error {
 	s3ObjectPath := strings.TrimPrefix(s3URL.Path, "/")
 
 	if uploadForce {
-		API.RemoveImage(amiName, imageName, s3BucketName, s3ObjectPath, nil)
+		s3object := aws.BucketObject{
+			Bucket: s3BucketName,
+			Path:   s3ObjectPath,
+		}
+		API.RemoveImage(amiName, imageName, s3object, nil)
 	}
 
 	// if no snapshot was specified, check for an existing one or a

--- a/cmd/plume/prerelease.go
+++ b/cmd/plume/prerelease.go
@@ -423,7 +423,12 @@ func awsUploadToPartition(spec *channelSpec, part *awsPartitionSpec, imagePath s
 	}
 
 	if force {
-		err := api.RemoveImage(imageName, imageName, part.Bucket, s3ObjectPath, destRegions)
+		s3object := aws.BucketObject{
+			Region: part.BucketRegion,
+			Bucket: part.Bucket,
+			Path:   s3ObjectPath,
+		}
+		err := api.RemoveImage(imageName, imageName, s3object, destRegions)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/plume/prune.go
+++ b/cmd/plume/prune.go
@@ -319,7 +319,12 @@ func pruneAWS(ctx context.Context, spec *channelSpec) {
 					// Remove -hvm from the name, as the snapshots don't include that.
 					imageName := strings.TrimSuffix(*image.Name, "-hvm")
 
-					err := api.RemoveImage(imageName, imageName, part.Bucket, s3ObjectPath, nil)
+					s3object := aws.BucketObject{
+						Region: part.BucketRegion,
+						Bucket: part.Bucket,
+						Path:   s3ObjectPath,
+					}
+					err := api.RemoveImage(imageName, imageName, s3object, nil)
 					if err != nil {
 						plog.Fatalf("couldn't prune image %v: %v", *image.Name, err)
 					}


### PR DESCRIPTION
# AWS prune all snapshots

We have a job that runs `plume prune` on all channels to cleanup older ec2 images. This has not worked yet, because of two issues (second one uncovered after fixing first one):
* `plume prune` uses the current regions auth token when iterating, which does results in an error from the S3 object deletion which is tied to a single region. Handle region switching to delete the object from the bucket if necessary.
* for old releases (eg. alpha-2121.0.0), the snapshot search finds two matching snapshots (one for hvm, one for non-hvm). This causes the removal to be aborted with an error. Handle this by deleting both snapshots, since the function can handle failure to delete snapshots.

## How to use

```
bin/plume prune --days 365 --keep-last 2 --days-soft-deleted 21 --check-last-launched --days-last-launched 60 --verbose --channel=alpha --aws-credentials=...
```

## Testing done

Ran the `plume prune` command above but with the following change to the code:
```diff
diff --git a/platform/api/aws/images.go b/platform/api/aws/images.go
index 143c0c77..c8ab713a 100644
--- a/platform/api/aws/images.go
+++ b/platform/api/aws/images.go
@@ -379,7 +379,7 @@ func (a *API) deregisterImageIfExists(name string) error {
 		return err
 	}
 	if imageID != "" {
-		_, err := a.ec2.DeregisterImage(&ec2.DeregisterImageInput{ImageId: &imageID})
+		//_, err := a.ec2.DeregisterImage(&ec2.DeregisterImageInput{ImageId: &imageID})
 		if err != nil {
 			return err
 		}
@@ -400,7 +400,9 @@ func (a *API) RemoveImage(amiName, imageName string, s3object BucketObject, othe
 		}
 		s3a = aa
 	}
-	err := s3a.DeleteObject(s3object.Bucket, s3object.Path)
+	var err error = nil
+	_ = s3a
+	//err := s3a.DeleteObject(s3object.Bucket, s3object.Path)
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok {
 			if awsErr.Code() != "NoSuchKey" {
@@ -438,7 +440,7 @@ func (a *API) RemoveImage(amiName, imageName string, s3object BucketObject, othe
 		for _, snapshot := range snapshots {
 			// We explicitly ignore errors here in case somehow another AMI was based
 			// on that snapshot
-			_, err := aa.ec2.DeleteSnapshot(&ec2.DeleteSnapshotInput{SnapshotId: &snapshot.SnapshotID})
+			//_, err := aa.ec2.DeleteSnapshot(&ec2.DeleteSnapshotInput{SnapshotId: &snapshot.SnapshotID})
 			if err != nil {
 				plog.Warningf("Failed to delete snapshot %s: %v", snapshot.SnapshotID, err)
 			} else {
```
This returns:
```
2022-09-07T17:19:17Z prune:us-east-1: Obsolete image "Flatcar-alpha-2135.0.0-hvm"/"ami-05c2e08cf8a845638": 1219 days old
2022-09-07T17:19:17Z platform/api/aws: Deleted existing S3 object bucket:flatcar-prod-ami-import-eu-central-1 path:amd64-usr/2135.0.0/flatcar_production_ami_vmdk_image.vmdk
2022-09-07T17:19:17Z platform/api/aws: Trying to deregister Flatcar-alpha-2135.0.0 in us-east-1
2022-09-07T17:19:17Z platform/api/aws: Deregistered existing image ami-05c2e08cf8a845638
2022-09-07T17:19:18Z platform/api/aws: Deregistered existing image ami-0a66bf2e07a9dbd97
2022-09-07T17:19:18Z platform/api/aws: Found existing snapshot snap-0606c8a06255fe93f
2022-09-07T17:19:18Z platform/api/aws: Found existing snapshot snap-052cbe75f7cdc69b7
2022-09-07T17:19:18Z platform/api/aws: Deleted existing snapshot snap-0606c8a06255fe93f
2022-09-07T17:19:18Z platform/api/aws: Deleted existing snapshot snap-052cbe75f7cdc69b7
```
which is what the expected output.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
