### PR TITLE
plume: update GCS URL to bincache URL

### DIFF
--- a/cmd/plume/containerlinux.go
+++ b/cmd/plume/containerlinux.go
@@ -102,7 +102,7 @@ var (
 
 	specs = map[string]channelSpec{
 		"alpha": channelSpec{
-			BaseURL:      "gs://flatcar-jenkins/alpha/boards",
+			BaseURL:      "http://bincache.flatcar-linux.net/images",
 			Boards:       []string{"amd64-usr", "arm64-usr"},
 			Destinations: []storageSpec{},
 			GCE:          newGceSpec("alpha", alpha_desc),
@@ -111,7 +111,7 @@ var (
 			AWS:          newAWSSpec(),
 		},
 		"beta": channelSpec{
-			BaseURL:      "gs://flatcar-jenkins/beta/boards",
+			BaseURL:      "http://bincache.flatcar-linux.net/images",
 			Boards:       []string{"amd64-usr", "arm64-usr"},
 			Destinations: []storageSpec{},
 			GCE:          newGceSpec("beta", beta_desc),
@@ -120,7 +120,7 @@ var (
 			AWS:          newAWSSpec(),
 		},
 		"stable": channelSpec{
-			BaseURL:      "gs://flatcar-jenkins/stable/boards",
+			BaseURL:      "http://bincache.flatcar-linux.net/images",
 			Boards:       []string{"amd64-usr", "arm64-usr"},
 			Destinations: []storageSpec{},
 			GCE:          newGceSpec("stable", stable_desc),
@@ -129,7 +129,7 @@ var (
 			AWS:          newAWSSpec(),
 		},
 		"edge": channelSpec{
-			BaseURL:      "gs://flatcar-jenkins/edge/boards",
+			BaseURL:      "http://bincache.flatcar-linux.net/images",
 			Boards:       []string{"amd64-usr", "arm64-usr"},
 			Destinations: []storageSpec{},
 			GCE:          newGceSpec("edge", edge_desc),
@@ -138,7 +138,7 @@ var (
 			AWS:          newAWSSpec(),
 		},
 		"lts": channelSpec{
-			BaseURL:      "gs://flatcar-jenkins/lts/boards",
+			BaseURL:      "http://bincache.flatcar-linux.net/images",
 			Boards:       []string{"amd64-usr", "arm64-usr"},
 			Destinations: []storageSpec{},
 			GCE:          newGceSpec("lts", lts_desc),
@@ -147,7 +147,7 @@ var (
 			AWS:          newAWSSpec(),
 		},
 		"developer": channelSpec{
-			BaseURL:      "gs://flatcar-jenkins/developer/developer/boards",
+			BaseURL:      "http://bincache.flatcar-linux.net/images",
 			Boards:       []string{"amd64-usr", "arm64-usr"},
 			Destinations: []storageSpec{},
 			GCE:          gceSpec{},

--- a/cmd/plume/containerlinux.go
+++ b/cmd/plume/containerlinux.go
@@ -102,64 +102,58 @@ var (
 
 	specs = map[string]channelSpec{
 		"alpha": channelSpec{
-			BaseURL:        "gs://flatcar-jenkins/alpha/boards",
-			BasePrivateURL: "gs://flatcar-jenkins-private/alpha/boards",
-			Boards:         []string{"amd64-usr", "arm64-usr"},
-			Destinations:   []storageSpec{},
-			GCE:            newGceSpec("alpha", alpha_desc),
-			Azure:          newAzureSpec(azureEnvironments, "publish", "Flatcar Alpha", "", alpha_desc),
-			AzurePremium:   newAzureSpec(azureEnvironments, "publish", "Flatcar Alpha", "", alpha_desc),
-			AWS:            newAWSSpec(),
+			BaseURL:      "gs://flatcar-jenkins/alpha/boards",
+			Boards:       []string{"amd64-usr", "arm64-usr"},
+			Destinations: []storageSpec{},
+			GCE:          newGceSpec("alpha", alpha_desc),
+			Azure:        newAzureSpec(azureEnvironments, "publish", "Flatcar Alpha", "", alpha_desc),
+			AzurePremium: newAzureSpec(azureEnvironments, "publish", "Flatcar Alpha", "", alpha_desc),
+			AWS:          newAWSSpec(),
 		},
 		"beta": channelSpec{
-			BaseURL:        "gs://flatcar-jenkins/beta/boards",
-			BasePrivateURL: "gs://flatcar-jenkins-private/beta/boards",
-			Boards:         []string{"amd64-usr", "arm64-usr"},
-			Destinations:   []storageSpec{},
-			GCE:            newGceSpec("beta", beta_desc),
-			Azure:          newAzureSpec(azureEnvironments, "publish", "Flatcar Beta", "", beta_desc),
-			AzurePremium:   newAzureSpec(azureEnvironments, "publish", "Flatcar Beta", "", beta_desc),
-			AWS:            newAWSSpec(),
+			BaseURL:      "gs://flatcar-jenkins/beta/boards",
+			Boards:       []string{"amd64-usr", "arm64-usr"},
+			Destinations: []storageSpec{},
+			GCE:          newGceSpec("beta", beta_desc),
+			Azure:        newAzureSpec(azureEnvironments, "publish", "Flatcar Beta", "", beta_desc),
+			AzurePremium: newAzureSpec(azureEnvironments, "publish", "Flatcar Beta", "", beta_desc),
+			AWS:          newAWSSpec(),
 		},
 		"stable": channelSpec{
-			BaseURL:        "gs://flatcar-jenkins/stable/boards",
-			BasePrivateURL: "gs://flatcar-jenkins-private/stable/boards",
-			Boards:         []string{"amd64-usr", "arm64-usr"},
-			Destinations:   []storageSpec{},
-			GCE:            newGceSpec("stable", stable_desc),
-			Azure:          newAzureSpec(azureEnvironments, "publish", "Flatcar Stable", "", stable_desc),
-			AzurePremium:   newAzureSpec(azureEnvironments, "publish", "Flatcar Stable", "", stable_desc),
-			AWS:            newAWSSpec(),
+			BaseURL:      "gs://flatcar-jenkins/stable/boards",
+			Boards:       []string{"amd64-usr", "arm64-usr"},
+			Destinations: []storageSpec{},
+			GCE:          newGceSpec("stable", stable_desc),
+			Azure:        newAzureSpec(azureEnvironments, "publish", "Flatcar Stable", "", stable_desc),
+			AzurePremium: newAzureSpec(azureEnvironments, "publish", "Flatcar Stable", "", stable_desc),
+			AWS:          newAWSSpec(),
 		},
 		"edge": channelSpec{
-			BaseURL:        "gs://flatcar-jenkins/edge/boards",
-			BasePrivateURL: "gs://flatcar-jenkins-private/edge/boards",
-			Boards:         []string{"amd64-usr", "arm64-usr"},
-			Destinations:   []storageSpec{},
-			GCE:            newGceSpec("edge", edge_desc),
-			Azure:          newAzureSpec(azureEnvironments, "publish", "Flatcar Edge", "", edge_desc),
-			AzurePremium:   newAzureSpec(azureEnvironments, "publish", "Flatcar Edge", "", edge_desc),
-			AWS:            newAWSSpec(),
+			BaseURL:      "gs://flatcar-jenkins/edge/boards",
+			Boards:       []string{"amd64-usr", "arm64-usr"},
+			Destinations: []storageSpec{},
+			GCE:          newGceSpec("edge", edge_desc),
+			Azure:        newAzureSpec(azureEnvironments, "publish", "Flatcar Edge", "", edge_desc),
+			AzurePremium: newAzureSpec(azureEnvironments, "publish", "Flatcar Edge", "", edge_desc),
+			AWS:          newAWSSpec(),
 		},
 		"lts": channelSpec{
-			BaseURL:        "gs://flatcar-jenkins/lts/boards",
-			BasePrivateURL: "gs://flatcar-jenkins-private/lts/boards",
-			Boards:         []string{"amd64-usr", "arm64-usr"},
-			Destinations:   []storageSpec{},
-			GCE:            newGceSpec("lts", lts_desc),
-			Azure:          newAzureSpec(azureEnvironments, "publish", "Flatcar LTS", "", lts_desc),
-			AzurePremium:   newAzureSpec(azureEnvironments, "publish", "Flatcar LTS", "", lts_desc),
-			AWS:            newAWSSpec(),
+			BaseURL:      "gs://flatcar-jenkins/lts/boards",
+			Boards:       []string{"amd64-usr", "arm64-usr"},
+			Destinations: []storageSpec{},
+			GCE:          newGceSpec("lts", lts_desc),
+			Azure:        newAzureSpec(azureEnvironments, "publish", "Flatcar LTS", "", lts_desc),
+			AzurePremium: newAzureSpec(azureEnvironments, "publish", "Flatcar LTS", "", lts_desc),
+			AWS:          newAWSSpec(),
 		},
 		"developer": channelSpec{
-			BaseURL:        "gs://flatcar-jenkins/developer/developer/boards",
-			BasePrivateURL: "gs://flatcar-jenkins-private/developer/developer/boards",
-			Boards:         []string{"amd64-usr", "arm64-usr"},
-			Destinations:   []storageSpec{},
-			GCE:            gceSpec{},
-			Azure:          newAzureSpec(azureEnvironments, "developer", "Flatcar Developer Channel", "", dev_desc),
-			AzurePremium:   newAzureSpec(azureEnvironments, "developer", "Flatcar Developer Channel", "", dev_desc),
-			AWS:            newAWSSpec(),
+			BaseURL:      "gs://flatcar-jenkins/developer/developer/boards",
+			Boards:       []string{"amd64-usr", "arm64-usr"},
+			Destinations: []storageSpec{},
+			GCE:          gceSpec{},
+			Azure:        newAzureSpec(azureEnvironments, "developer", "Flatcar Developer Channel", "", dev_desc),
+			AzurePremium: newAzureSpec(azureEnvironments, "developer", "Flatcar Developer Channel", "", dev_desc),
+			AWS:          newAWSSpec(),
 		},
 	}
 )
@@ -320,9 +314,6 @@ func ChannelSpec() channelSpec {
 
 func (cs channelSpec) SourceURL() string {
 	baseURL := cs.BaseURL
-	if specPrivateBucket {
-		baseURL = cs.BasePrivateURL
-	}
 	if gceJSONKeyFile == "none" {
 		baseURL = strings.Replace(baseURL, "gs://", "https://bucket.release.flatcar-linux.net/", 1)
 	}
@@ -336,12 +327,7 @@ func (cs channelSpec) SourceURL() string {
 }
 
 func (ss storageSpec) ParentPrefixes() []string {
-	baseURL := ss.BaseURL
-	if specPrivateBucket {
-		baseURL = ss.BasePrivateURL
-	}
-
-	u, err := url.Parse(baseURL)
+	u, err := url.Parse(ss.BaseURL)
 	if err != nil {
 		panic(err)
 	}
@@ -349,12 +335,7 @@ func (ss storageSpec) ParentPrefixes() []string {
 }
 
 func (ss storageSpec) FinalPrefixes() []string {
-	baseURL := ss.BaseURL
-	if specPrivateBucket {
-		baseURL = ss.BasePrivateURL
-	}
-
-	u, err := url.Parse(baseURL)
+	u, err := url.Parse(ss.BaseURL)
 	if err != nil {
 		plog.Panic(err)
 	}

--- a/cmd/plume/types.go
+++ b/cmd/plume/types.go
@@ -15,13 +15,12 @@
 package main
 
 type storageSpec struct {
-	BaseURL        string
-	BasePrivateURL string
-	Title          string // Replace the bucket name in index page titles
-	NamedPath      string // Copy to $BaseURL/$Board/$NamedPath
-	VersionPath    bool   // Copy to $BaseURL/$Board/$Version
-	DirectoryHTML  bool
-	IndexHTML      bool
+	BaseURL       string
+	Title         string // Replace the bucket name in index page titles
+	NamedPath     string // Copy to $BaseURL/$Board/$NamedPath
+	VersionPath   bool   // Copy to $BaseURL/$Board/$Version
+	DirectoryHTML bool
+	IndexHTML     bool
 }
 
 type gceSpec struct {
@@ -72,14 +71,13 @@ type awsSpec struct {
 }
 
 type channelSpec struct {
-	BaseURL        string // Copy from $BaseURL/$Board/$Version
-	BasePrivateURL string
-	Boards         []string
-	Destinations   []storageSpec
-	GCE            gceSpec
-	Azure          azureSpec
-	AzurePremium   azureSpec
-	AWS            awsSpec
+	BaseURL      string // Copy from $BaseURL/$Board/$Version
+	Boards       []string
+	Destinations []storageSpec
+	GCE          gceSpec
+	Azure        azureSpec
+	AzurePremium azureSpec
+	AWS          awsSpec
 }
 
 type ReleaseMetadata struct {


### PR DESCRIPTION
* plume: remove BasePrivateURL
it's no more used.

* plume/release: update GCS URL to bincache URL

<hr>

I was expecting more complexity to update this URL but it seems that `storage` is able to understand both type of URL, it converts GCS URL to plain HTTP url: 
https://github.com/flatcar-linux/mantle/blob/fb7bbf6e2c863c0bcfb9dcba4c090e45eb8c4742/cmd/plume/containerlinux.go#L326-L328